### PR TITLE
feat: sort the language list by the language name, not code

### DIFF
--- a/packages/studio-web/src/app/upload/upload.component.ts
+++ b/packages/studio-web/src/app/upload/upload.component.ts
@@ -31,8 +31,14 @@ import { TextFormatDialogComponent } from "../text-format-dialog/text-format-dia
 export class UploadComponent implements OnInit {
   langs$ = this.rasService.getLangs$().pipe(
     map((langs: Array<SupportedLanguage>) =>
-      langs.map((lang) => {
+      langs
+      .map((lang) => {
         return { id: lang.code, name: lang.names["_"] };
+      })
+      .sort((a, b) => {
+        if (a.name < b.name) return -1;
+        if (a.name > b.name) return 1;
+        return 0;
       })
     )
   );


### PR DESCRIPTION
This is just because it's not intuitive to look for language in the drop-down list order of codes while lang names is what the display starts with.

Fixes: #94