### PR TITLE
fix: show error toast if ras api is unreachable

### DIFF
--- a/packages/studio-web/src/app/ras.service.spec.ts
+++ b/packages/studio-web/src/app/ras.service.spec.ts
@@ -1,4 +1,5 @@
 import { HttpClient, HttpEventType } from "@angular/common/http";
+import { ToastrModule } from "ngx-toastr";
 import {
   HttpClientTestingModule,
   HttpTestingController,
@@ -16,7 +17,7 @@ describe("RasService", () => {
   beforeEach(() => {
     httpClientSpy = jasmine.createSpyObj("HttpClient", ["get"]);
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
+      imports: [HttpClientTestingModule, ToastrModule.forRoot()],
     });
     // Inject the http service and test controller for each test
     httpClient = TestBed.inject(HttpClient);

--- a/packages/studio-web/src/app/ras.service.ts
+++ b/packages/studio-web/src/app/ras.service.ts
@@ -1,6 +1,7 @@
-import { Observable } from "rxjs";
+import { catchError, Observable, of } from "rxjs";
+import { ToastrService } from "ngx-toastr";
 
-import { HttpClient } from "@angular/common/http";
+import { HttpClient, HttpErrorResponse } from "@angular/common/http";
 import { Injectable } from "@angular/core";
 import { DictEntry } from "soundswallower";
 
@@ -33,11 +34,21 @@ export interface SupportedLanguage {
 })
 export class RasService {
   baseURL = environment.apiBaseURL;
-  constructor(private http: HttpClient) {}
-  assembleReadalong$(body: ReadAlongRequest): Observable<ReadAlong> {
-    return this.http.post<ReadAlong>(this.baseURL + "/assemble", body);
+  constructor(private http: HttpClient, private toastr: ToastrService,) {}
+  assembleReadalong$(body: ReadAlongRequest): Observable<ReadAlong|HttpErrorResponse> {
+    return this.http.post<ReadAlong>(this.baseURL + "/assemble", body).pipe(
+      catchError((err: HttpErrorResponse) => { this.toastr.error(
+        err.message,
+        $localize`Hmm, we can't connect to the ReadAlongs API. Please try again later.`
+      ); return of(err)} )
+    );
   }
-  getLangs$(): Observable<Array<SupportedLanguage>> {
-    return this.http.get<Array<SupportedLanguage>>(this.baseURL + "/langs");
+  getLangs$(): Observable<Array<SupportedLanguage>|HttpErrorResponse> {
+    return this.http.get<Array<SupportedLanguage>>(this.baseURL + "/langs").pipe(
+      catchError((err: HttpErrorResponse) => { this.toastr.error(
+        err.message,
+        $localize`Hmm, we can't connect to the ReadAlongs API. Please try again later.`
+      ); return of(err)} )
+    );;
   }
 }

--- a/packages/studio-web/src/app/ras.service.ts
+++ b/packages/studio-web/src/app/ras.service.ts
@@ -39,7 +39,10 @@ export class RasService {
     return this.http.post<ReadAlong>(this.baseURL + "/assemble", body).pipe(
       catchError((err: HttpErrorResponse) => { this.toastr.error(
         err.message,
-        $localize`Hmm, we can't connect to the ReadAlongs API. Please try again later.`
+        $localize`Hmm, we can't connect to the ReadAlongs API. Please try again later.`,
+        {
+          timeOut: 60000,
+        }
       ); return of(err)} )
     );
   }
@@ -47,7 +50,10 @@ export class RasService {
     return this.http.get<Array<SupportedLanguage>>(this.baseURL + "/langs").pipe(
       catchError((err: HttpErrorResponse) => { this.toastr.error(
         err.message,
-        $localize`Hmm, we can't connect to the ReadAlongs API. Please try again later.`
+        $localize`Hmm, we can't connect to the ReadAlongs API. Please try again later.`,
+        {
+          timeOut: 60000,
+        }
       ); return of(err)} )
     );;
   }

--- a/packages/studio-web/src/app/upload/upload.component.ts
+++ b/packages/studio-web/src/app/upload/upload.component.ts
@@ -1,7 +1,7 @@
 // -*- typescript-indent-level: 2 -*-
 import { ToastrService } from "ngx-toastr";
 import { Observable, forkJoin, of, zip } from "rxjs";
-import { map, switchMap, take } from "rxjs/operators";
+import { map, switchMap, take, takeWhile, tap } from "rxjs/operators";
 
 import { Component, EventEmitter, OnInit, Output } from "@angular/core";
 import { FormBuilder, FormControl, Validators } from "@angular/forms";
@@ -22,6 +22,7 @@ import {
   AlignmentProgress,
 } from "../soundswallower.service";
 import { TextFormatDialogComponent } from "../text-format-dialog/text-format-dialog.component";
+import { HttpErrorResponse } from "@angular/common/http";
 
 @Component({
   selector: "app-upload",
@@ -30,8 +31,10 @@ import { TextFormatDialogComponent } from "../text-format-dialog/text-format-dia
 })
 export class UploadComponent implements OnInit {
   langs$ = this.rasService.getLangs$().pipe(
-    map((langs: Array<SupportedLanguage>) =>
-      langs
+    map((langs: Array<SupportedLanguage>|HttpErrorResponse) =>
+    {
+    if (Array.isArray(langs)) {
+      return langs
       .map((lang) => {
         return { id: lang.code, name: lang.names["_"] };
       })
@@ -40,7 +43,12 @@ export class UploadComponent implements OnInit {
         if (a.name > b.name) return 1;
         return 0;
       })
-    )
+    } else {
+      return []
+    }
+  }
+    ) 
+
   );
   loading = false;
   langControl = new FormControl<string>("und", Validators.required);
@@ -236,7 +244,7 @@ export class UploadComponent implements OnInit {
           8000
         ),
         ras: this.fileService.readFile$(this.textControl.value).pipe(
-          switchMap((text: string): Observable<ReadAlong> => {
+          switchMap((text: string): Observable<ReadAlong|HttpErrorResponse> => {
             body.input = text;
             this.progressMode = "determinate";
             this.progressValue = 0;
@@ -245,6 +253,10 @@ export class UploadComponent implements OnInit {
         ),
       })
         .pipe(
+          tap((joined_audio_and_ras: any) => {if (joined_audio_and_ras.ras instanceof HttpErrorResponse) {
+            this.loading = false;
+          } }),
+          takeWhile((joined_audio_and_ras: any) => !(joined_audio_and_ras.ras instanceof HttpErrorResponse)),
           switchMap(({ audio, ras }) =>
             // We can't give the arguments types because RxJS is broken somehow,
             // see https://stackoverflow.com/questions/66615681/rxjs-switchmap-mergemap-resulting-in-obserableunknown

--- a/packages/studio-web/src/i18n/messages.fr.json
+++ b/packages/studio-web/src/i18n/messages.fr.json
@@ -16,6 +16,7 @@
     "8439955599488894226": "Politique de vie privée",
     "9145384756401372637": "Cet outil a été conçu avec le but principal de respecter votre vie privée et la souveraineté de vos données. L'audio que vous rentrez sur ce site {$START_BOLD_TEXT}ne sera jamais téléversé{$CLOSE_BOLD_TEXT} mais restera sur votre ordinateur. Le texte que vous utilisez pour ce ReadAlong sera transféré à un serveur par une connection chiffrée pour accomplir le traitement nécessaire, mais ne sera ni sauvegardé ni utilisé à d'autres fins. Votre utilisation de ce site indique votre accord avec cette utilisation de vos données.\n",
     "1708201283688549233": "D'accord",
+    "6017683769837067192": "Désolé, nous ne pouvons pas rejoindre le serveur ReadAlongs. Prière de réessayer plus tard.",
     "3554456208146982911": "Bienvenue au Studio ReadAlong\n",
     "1309246714146466494": "Il est facile de créer un ReadAlong!  Vous trouverez tous les trucs et astuces pour utiliser le Studio dans cette visite guidée.",
     "3885497195825665706": "Continuer",

--- a/packages/studio-web/src/i18n/messages.json
+++ b/packages/studio-web/src/i18n/messages.json
@@ -16,6 +16,7 @@
     "8439955599488894226": "Privacy Policy",
     "9145384756401372637": " We have built this tool with the top goal of respecting your privacy and data sovereignty. The audio that you use on this site {$START_BOLD_TEXT}does not get uploaded anywhere{$CLOSE_BOLD_TEXT}. It will stay on your computer. The text you use for this Read Along will be uploaded over an encrypted connection to a server for preprocessing. The text is not saved and is not used for any other purpose. Using this site means that you agree for your data to be used in this way.\n",
     "1708201283688549233": "I agree",
+    "6017683769837067192": "Hmm, we can't connect to the ReadAlongs Server. Please try again later.",
     "3554456208146982911": "Welcome to ReadAlong Studio\n",
     "1309246714146466494": "Creating a ReadAlong is easy!    This guide will show you all the bells and whistles of the Studio.",
     "3885497195825665706": "Next",


### PR DESCRIPTION
Shows this now when the RAS api is down:

![image](https://user-images.githubusercontent.com/14815080/219146153-43f4b66c-dd70-49fb-a661-3a42c6dbca5b.png)

It will also stop the loading bar and reset back to a functional state.