### PR TITLE
Disable recording button while we are trying to start to record

### DIFF
--- a/packages/studio-web/src/app/upload/upload.component.html
+++ b/packages/studio-web/src/app/upload/upload.component.html
@@ -165,6 +165,7 @@
               (click)="startRecording()"
               [color]="recording ? 'warn' : 'primary'"
               aria-label="Record button"
+              [disabled]="starting_to_record"
             >
               <mat-icon class="mat-icon-lg">mic</mat-icon>
               <span

--- a/packages/studio-web/src/app/upload/upload.component.ts
+++ b/packages/studio-web/src/app/upload/upload.component.ts
@@ -50,6 +50,7 @@ export class UploadComponent implements OnDestroy, OnInit {
   langControl = new FormControl<string>("und", Validators.required);
   textControl = new FormControl<any>(null, Validators.required);
   audioControl = new FormControl<File | Blob | null>(null, Validators.required);
+  starting_to_record = false;
   recording = false;
   playing = false;
   player: any = null;
@@ -189,10 +190,13 @@ export class UploadComponent implements OnDestroy, OnInit {
 
   async startRecording() {
     try {
+      this.starting_to_record = true;
       await this.microphoneService.startRecording();
       this.recording = true;
     } catch (err: any) {
       this.toastr.error(err.toString(), $localize`Could not start recording!`);
+    } finally {
+      this.starting_to_record = false;
     }
   }
 

--- a/packages/studio-web/src/i18n/messages.fr.json
+++ b/packages/studio-web/src/i18n/messages.fr.json
@@ -107,7 +107,7 @@
     "6558433540988178003": "Pas de texte à télécharger.",
     "4183225119057268962": "Impossible de démarrer l'enregistrement!",
     "2596823344081631983": "Audio enregistré avec succès. Prière d'écouter votre enregistrement pour le valider et de le sauvegarder s'il est bon.",
-    "1317075918959775059": "Hourra!",
+    "1317075918959775059": "Bravo!",
     "3585637900550692820": "Impossible d'enregistrer, prière de vérifier que votre microphone est bien connecté et activé.  Si le problème perdure, réessayez avec une casque d'écoute ou autre microphone.",
     "1983793909601149790": "Prière de réessayer ou de choisir un fichier pré-enregistré.",
     "779265781994803872": "Erreur d'enregistrement",


### PR DESCRIPTION
Another UX tweak: when I first click on Record after leading the app, it can take a few seconds to start, during which it's not clear anything is happening. Solution: disable the button so it's grayed out while we're trying to launch the recorder.

Also, "Hourra!" just sounds too childish to me, it bugs me every time I see that message. I switched it to "Bravo!" which is a little better.