### PR TITLE
ci: make extract-i18n check order agnostic for messages.json too

### DIFF
--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -30,5 +30,5 @@ jobs:
       - name: Check that i18n and l10n are up to date
         run: |
           npx nx extract-i18n studio-web
-          if git diff -w --numstat | grep i18n/messages; then echo ERROR: The i18n database is out of date.; git diff; npx nx check-fr-l10n studio-web || echo ERROR: The fr l10n database is also out of date.; false; else echo OK: The i18n database is up to date.; fi
+          if diff -w <(git show HEAD:packages/studio-web/src/i18n/messages.json | sort) <(sort < packages/studio-web/src/i18n/messages.json); then echo OK: The i18n database is up to date.; else echo ERROR: The i18n database is out of date.; npx nx check-fr-l10n studio-web || echo ERROR: The fr l10n database is also out of date.; false; fi
           if npx nx check-fr-l10n studio-web; then echo OK: The fr l10n database is up to date.; else echo ERROR: The fr l10n database is out of date.; false; fi


### PR DESCRIPTION
When the order of strings in `messages.json` changes but they're the same strings, we really don't care...

To do, eventually: move my ugly scripts from the recipe itself into regular scripts in `/bin/` or some such, and make it legible. But not today!