### PR TITLE
feat: rename Save button to Save a copy for better clarity

### DIFF
--- a/packages/studio-web/src/app/upload/upload.component.html
+++ b/packages/studio-web/src/app/upload/upload.component.html
@@ -91,7 +91,7 @@
                 aria-label="Text download button"
                 class="pr-0"
               >
-                <mat-icon class="mat-icon-lg">save</mat-icon> Save
+                <mat-icon class="mat-icon-lg">save</mat-icon> Save a copy
               </button>
             </span>
           </div>
@@ -197,7 +197,7 @@
           </div>
         </div>
         <div class="row">
-          <div class="col-12 col-lg-4">
+          <div class="col-12 col-xl-4">
             <button
               i18n="Audio play button"
               class="audioControl"
@@ -223,7 +223,7 @@
               Stop
             </button>
           </div>
-          <div class="col-12 col-lg-4">
+          <div class="col-12 col-xl-4">
             <button
               i18n="Audio download button"
               class="audioControl"
@@ -235,10 +235,10 @@
               aria-label="Audio save button"
             >
               <mat-icon class="mat-icon-lg">save</mat-icon>
-              Save
+              Save a copy
             </button>
           </div>
-          <div class="col-12 col-lg-4">
+          <div class="col-12 col-xl-4">
             <button
               i18n="Audio delete button"
               class="audioControl"

--- a/packages/studio-web/src/i18n/messages.fr.json
+++ b/packages/studio-web/src/i18n/messages.fr.json
@@ -87,7 +87,7 @@
     "323794992596449638": "Sélectionnez un fichier de texte brut (.txt) ou un fichier ReadAlong Studio (.readalong)",
     "6329500169661407619": " Rédigez ou collez votre texte ici ",
     "887019029800317757": "{$START_TAG_MAT_ICON}help_outline{$CLOSE_TAG_MAT_ICON} Format ",
-    "7134732939442782683": "{$START_TAG_MAT_ICON}save{$CLOSE_TAG_MAT_ICON} Sauvegarder ",
+    "4289685560479120097": "{$START_TAG_MAT_ICON}save{$CLOSE_TAG_MAT_ICON} Copie de sauvegarde ",
     "7534891070879763001": "Ex. Bonjour, je m'appelle...",
     "347407180135731058": "Audio",
     "6150173052210897773": "Enregistrer",

--- a/packages/studio-web/src/i18n/messages.json
+++ b/packages/studio-web/src/i18n/messages.json
@@ -87,7 +87,7 @@
     "323794992596449638": "Select a plain text file (.txt) or a ReadAlong Studio temporary file (.readalong)",
     "6329500169661407619": " Write or paste your text here ",
     "887019029800317757": "{$START_TAG_MAT_ICON}help_outline{$CLOSE_TAG_MAT_ICON} Format ",
-    "7134732939442782683": "{$START_TAG_MAT_ICON}save{$CLOSE_TAG_MAT_ICON} Save ",
+    "4289685560479120097": "{$START_TAG_MAT_ICON}save{$CLOSE_TAG_MAT_ICON} Save a copy ",
     "7534891070879763001": "Ex. Hello my name is...",
     "347407180135731058": "Audio",
     "6150173052210897773": "Record",


### PR DESCRIPTION
This PR is fine for the most part, except I don't like how the button is displayed on narrow screens:

![image](https://user-images.githubusercontent.com/33264708/221032184-80a9b73f-80b1-4f3e-b135-ce49a0cadc7a.png)
![image](https://user-images.githubusercontent.com/33264708/221032229-41eb2263-2cd0-4741-8ccd-bfa2a0a17b48.png)

Fixes #160 