### PR TITLE
Tweak the list of accepted audio formats

### DIFF
--- a/packages/studio-web/src/app/upload/upload.component.html
+++ b/packages/studio-web/src/app/upload/upload.component.html
@@ -134,7 +134,7 @@
             i18n="Instructions for uploading audio"
             for="updateAudio"
             class="form-label"
-            >Use pre-recorded audio from an mp3, wav, or webm file.</label
+            >Use pre-recorded audio from an MP3 or WAV file.</label
           >
           <input
             (change)="onFileSelected('audio', $event)"
@@ -142,7 +142,7 @@
             name="audio"
             type="file"
             id="updateAudio"
-            accept=".mp3,.wav,.webm"
+            accept=".mp3,.wav,.webm,.m4a"
           />
         </div>
         <div *ngIf="inputMethod.audio === 'mic'" class="mb-0 mb-md-3">

--- a/packages/studio-web/src/i18n/messages.fr.json
+++ b/packages/studio-web/src/i18n/messages.fr.json
@@ -94,7 +94,7 @@
     "347407180135731058": "Audio",
     "6150173052210897773": "Enregistrer",
     "5893500762826563625": " Choisir un fichier audio ",
-    "5685748095011794109": "Votre fichier audio doit être en format mp3, wav ou webm.",
+    "7124627482150867570": "Utilisez un fichier pré-enregistré de format MP3 ou WAV.",
     "5613657256708794361": " Enregistrez votre voix ici ",
     "1040741403296498484": "Effacer et réenregistrer",
     "6543643564103016190": "Enregistrement en cours",

--- a/packages/studio-web/src/i18n/messages.json
+++ b/packages/studio-web/src/i18n/messages.json
@@ -94,7 +94,7 @@
     "347407180135731058": "Audio",
     "6150173052210897773": "Record",
     "5893500762826563625": " Select an audio file ",
-    "5685748095011794109": "Use pre-recorded audio from an mp3, wav, or webm file.",
+    "7124627482150867570": "Use pre-recorded audio from an MP3 or WAV file.",
     "5613657256708794361": " Record your voice here ",
     "1040741403296498484": "Delete and re-record",
     "6543643564103016190": "Recording",


### PR DESCRIPTION
…M4A and WEBM

.webm is an obscure format, most user will not know what it is. We have to support it since the Save button generates it on Windows, but it's enough to support it. Having it in the `accept` list means it'll be avaiable to select so it should not be (too) confusing.

I'm also adding .m4a to the `accept` list (without mentioning it in the text) because on Windows, that's the default format you get when you record, and it's the format of my sample in the Studio.git repo that found its way everywhere, so we really should allow selecting it!

Fixes #161