### PR TITLE
Detect and report g2p warnings

### DIFF
--- a/packages/studio-web/src/app/ras.service.ts
+++ b/packages/studio-web/src/app/ras.service.ts
@@ -14,6 +14,7 @@ export interface ReadAlong {
   parsed: string | null;
   tokenized: string | null;
   g2ped: string | null;
+  log: string | null;
 }
 
 export interface ReadAlongRequest {

--- a/packages/studio-web/src/app/upload/upload.component.ts
+++ b/packages/studio-web/src/app/upload/upload.component.ts
@@ -357,7 +357,7 @@ Please check it to make sure all words are spelled out completely, e.g. write "4
           switchMap(
             ({ audio, ras }: { audio: AudioBuffer; ras: ReadAlong }) => {
               if (ras.log !== null) {
-                const fallbackRx = /Could not g2p.*\n/g;
+                const fallbackRx = /^.*g2p.*$/gim;
                 const matches = ras.log.match(fallbackRx);
                 if (matches) {
                   this.toastr.warning(

--- a/packages/studio-web/src/app/upload/upload.component.ts
+++ b/packages/studio-web/src/app/upload/upload.component.ts
@@ -136,7 +136,7 @@ export class UploadComponent implements OnDestroy, OnInit {
 to the text.`,
         $localize`Alignment failed.`,
         {
-          timeOut: 15000,
+          timeOut: 30000,
         }
       );
     } else {
@@ -145,7 +145,7 @@ to the text.`,
 Please check it to make sure all words are spelled out completely, e.g. write "42" as "forty two".`,
         $localize`Alignment failed.`,
         {
-          timeOut: 15000,
+          timeOut: 30000,
         }
       );
     }
@@ -363,7 +363,7 @@ Please check it to make sure all words are spelled out completely, e.g. write "4
                   this.toastr.warning(
                     matches.join("\n"),
                     $localize`Possible text processing issues.`,
-                    { timeOut: 15000 }
+                    { timeOut: 30000 }
                   );
                 }
               }

--- a/packages/studio-web/src/i18n/messages.fr.json
+++ b/packages/studio-web/src/i18n/messages.fr.json
@@ -126,6 +126,7 @@
     "3578398528078428417": "Prière de choisir un fichier texte.",
     "4603453641249002294": "Désolé, le modèle d'alignement n'est pas encore chargé. Prière d'attendre un peu et de réessayer si vous utilisez une connection lente. Si le problème perdure, prière de nous contacter.",
     "3861272198542491849": "Modèle non chargé",
+    "7614709406289221963": "Problèmes potentiels de traitement de texte.",
     "7051563249389544165": "Prière de choisir une langue.",
     "5845021075215482602": "Pas de langue",
     "7528020111424948593": "Prière de (ré-)enregistrer votre voix ou de choisir un fichier audio.",

--- a/packages/studio-web/src/i18n/messages.json
+++ b/packages/studio-web/src/i18n/messages.json
@@ -126,6 +126,7 @@
     "3578398528078428417": "Please select a text file.",
     "4603453641249002294": "Sorry, the alignment model isn't loaded yet. Please wait a while and try again if you're on a slow connection. If the problem persists, please contact us.",
     "3861272198542491849": "No model loaded",
+    "7614709406289221963": "Possible text processing issues.",
     "7051563249389544165": "Please select a language.",
     "5845021075215482602": "No language",
     "7528020111424948593": "Please (re-)record some audio or select an audio file.",

--- a/packages/studio-web/src/mocks/index.ts
+++ b/packages/studio-web/src/mocks/index.ts
@@ -267,4 +267,5 @@ export const ASSEMBLE_MOCK: ReadAlong = {
   parsed: null,
   tokenized: null,
   g2ped: null,
+  log: null,
 };


### PR DESCRIPTION
Gives a nice and helpful warning box with all the fallback/g2p failures in the log.  Note that:

- There could be a *lot* of warnings
- Not sure how to put line breaks between them (it doesn't seem possible, unfortunately)
