### PR TITLE
ci: bump gh pages action to use node 16

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
           npx nx build studio-web --configuration=production --localize=fr --deleteOutputPath=false
           npx nx build studio-web --configuration=production --localize=es --deleteOutputPath=false
       - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@v4.2.3
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages # The branch the action should deploy to.
           folder: dist/packages/studio-web # The folder the action should deploy.


### PR DESCRIPTION
Use @v4 to get the latest, currently 4.4.1, which fixes the warnings we get.

Tested on a different site, works correctly.