### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: fregante/setup-git-user@v1
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v3
@@ -43,20 +43,20 @@ jobs:
       - name: Determine tag
         id: determine_tag
         run: |
-          echo "::set-output name=TAG_VERSION::$(npm view @readalongs/web-component version)"
+          echo "TAG_VERSION=$(npm view @readalongs/web-component version)" >> $GITHUB_OUTPUT
       - name: Bump version and push tag
         id: tag_version
-        uses: mathieudutour/github-tag-action@v5.5
+        uses: mathieudutour/github-tag-action@v6.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           custom_tag: ${{ steps.determine_tag.outputs.TAG_VERSION }}
       - name: Create a GitHub release
-        uses: actions/create-release@v1
+        uses: ncipollo/release-action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ steps.tag_version.outputs.new_tag }}
-          release_name: Release ${{ steps.tag_version.outputs.new_tag }}
+          tag: ${{ steps.tag_version.outputs.new_tag }}
+          name: Release ${{ steps.tag_version.outputs.new_tag }}
           body: ${{ steps.tag_version.outputs.changelog }}
       - name: Commit bumped version and merge with main
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,12 +58,15 @@ jobs:
           tag: ${{ steps.tag_version.outputs.new_tag }}
           name: Release ${{ steps.tag_version.outputs.new_tag }}
           body: ${{ steps.tag_version.outputs.changelog }}
-      - name: Commit bumped version and merge with main
-        run: |
-          git add package.json packages/*/package.json packages/studio-web/src/assets/bundle.js packages/studio-web/src/assets/fonts.b64.css
-          git commit -m "chore: commit version"
-          git fetch --unshallow
-          git push origin release
-          git checkout main
-          git merge release
-          git push origin main
+      - name: Submit a PR for the bumped version
+        uses: peter-evans/create-pull-request@v4
+        with:
+          commit-message: "chore: commit version"
+          delete-branch: true
+          base: main
+          add-paths: |
+            package.json
+            package-lock.json
+            packages/*/package.json
+            packages/studio-web/src/assets/bundle.js
+            packages/studio-web/src/assets/fonts.b64.css


### PR DESCRIPTION
 - submit a PR for the updated files, since we cannot push to release or main
 - Remove Node 12 dependencies and other warnings

Fully tested in a separate repo.