### PR TITLE
clean up package.json and project.json for studio-web

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ If your Studio sandbox is in a sibling directory to this sandbox, and you Python
 
 Alternatively run together as:
 
-    nx run-many --targets=serve-test-data,serve-web-api,serve --projects=web-component,studio-web --parallel 5
+    nx run-many --targets=serve-test-data,serve-web-api,serve,serve-fr,serve-es --projects=web-component,studio-web --parallel 6
 
 Studio-Web will automatically [publish](.github/workflows/publish.yml) to https://readalong-studio.mothertongues.org/ every time there is a change to `main`.
 

--- a/README.md
+++ b/README.md
@@ -90,11 +90,15 @@ Ou en français (sur le port 4201 par défaut):
     nx serve studio-web --configuration=development-fr
 
 There are separate production and development serving configurations
-for each interface language, so you may for instance also use
+for each interface language defined in `packages/studio-web/project.json`, so you may for instance also use
 `development-en`, `production-en`, `development-es`, `production-es`, `production-fr`, etc for
 `--configuration` above. Note that these configurations are _only_
 for the `serve` command. To build for deployment, see
 [below](#studio-web-2).
+
+We have also defined targets `serve-fr` and `serve-es` in `project.json` so that you can launch the dev configs for all three supported languages at once with:
+
+    nx run-many --targets=serve,serve-fr,serve-es --projects=studio-web
 
 Note that you will need to also spin-up the ReadAlong-Studio API in order to have Studio-Web work properly. To do that, first clone the Python Package/API repo:
 

--- a/packages/studio-web/package.json
+++ b/packages/studio-web/package.json
@@ -6,20 +6,10 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
+    "helpme": "echo This project is part of a monorepo managed using nx. Run the targets in project.json using npx nx target studio-web at the root of the monorepo.",
     "ng": "ng",
-    "start": "ng serve",
-    "start-fr": "ng serve --configuration=fr --port=5200",
-    "start-es": "ng serve --configuration=es --port=5200",
-    "serve-web-api": "cd ../../../Studio/readalongs && PRODUCTION= DEVELOPMENT=1 uvicorn readalongs.web_api:web_api_app --reload",
-    "build": "ng build --configuration development --localize",
-    "build:prod": "ng build --configuration production --localize",
-    "build:prod:ghpages": "ng build --configuration production && ng build --configuration production,fr && ng build --configuration production,es",
-    "watch": "ng build --watch --configuration development --localize",
-    "test": "ng test",
-    "test:once": "ng test --watch=false --browsers ChromeHeadlessCI",
-    "extract-i18n": "ng extract-i18n --format json --output-path src/i18n; echo '' >> src/i18n/messages.json",
-    "check-fr-l10n": "bash -c \"diff -w <(cat src/i18n/messages.json | sed 's/:.*//' | sort) <(cat src/i18n/messages.fr.json | sed 's/:.*//' | sort)\"",
-    "check-es-l10n": "bash -c \"diff -w <(cat src/i18n/messages.json | sed 's/:.*//' | sort) <(cat src/i18n/messages.es.json | sed 's/:.*//' | sort)\""
+    "test:ng": "ng test",
+    "test:once": "ng test --watch=false --browsers ChromeHeadlessCI"
   },
   "private": true,
   "devDependencies": {

--- a/packages/studio-web/project.json
+++ b/packages/studio-web/project.json
@@ -100,6 +100,23 @@
       },
       "defaultConfiguration": "development-en"
     },
+    "serve-es": {
+      "executor": "@angular-builders/custom-webpack:dev-server",
+      "options": {
+        "browserTarget": "studio-web:build:development,es",
+        "port": 4202
+      }
+    },
+    "serve-fr": {
+      "executor": "@angular-builders/custom-webpack:dev-server",
+      "options": {
+        "browserTarget": "studio-web:build:development,fr",
+        "port": 4201
+      }
+    },
+    "serve-web-api": {
+      "command": "bash -c \"cd ../Studio/readalongs && PRODUCTION= DEVELOPMENT=1 uvicorn readalongs.web_api:web_api_app --reload\""
+    },
     "extract-i18n": {
       "executor": "@angular-builders/custom-webpack:extract-i18n",
       "options": {
@@ -107,6 +124,12 @@
         "outputPath": "packages/studio-web/src/i18n",
         "browserTarget": "studio-web:build"
       }
+    },
+    "check-fr-l10n": {
+      "command": "bash -c \"diff -w <(cat packages/studio-web/src/i18n/messages.json | sed 's/:.*//' | sort) <(cat packages/studio-web/src/i18n/messages.fr.json | sed 's/:.*//' | sort)\""
+    },
+    "check-es-l10n": {
+      "command": "bash -c \"diff -w <(cat packages/studio-web/src/i18n/messages.json | sed 's/:.*//' | sort) <(cat packages/studio-web/src/i18n/messages.es.json | sed 's/:.*//' | sort)\""
     },
     "lint": {
       "executor": "@nrwl/linter:eslint",


### PR DESCRIPTION
We had broken scripts left in packages/studio-web/package.json that only worked before this was a monorepo. I've deleted those lines, migrated others to project.json, removed duplicates, and added some documentation to help the new developer, and the returning developer who doesn't remember how things are setup three months later (i.e., me!).