### PR TITLE
fix: show the toast for digit errors again

### DIFF
--- a/packages/studio-web/src/app/upload/upload.component.ts
+++ b/packages/studio-web/src/app/upload/upload.component.ts
@@ -421,7 +421,7 @@ Please check it to make sure all words are spelled out completely, e.g. write "4
               }
               return throwError(() => err);
             } else {
-              return of(err);
+              return throwError(() => err);
             }
           }),
           retry(2),


### PR DESCRIPTION
solution details: throw unhandled errors back out for downstream handling