### PR TITLE
Close the microphone stream when done recording (fixes #213)

### DIFF
--- a/packages/studio-web/src/app/microphone.service.ts
+++ b/packages/studio-web/src/app/microphone.service.ts
@@ -7,14 +7,15 @@ export class MicrophoneService {
   private chunks: Array<Blob> = [];
   private recorder: MediaRecorder | null = null;
   private recorderEnded = new EventEmitter<Blob>();
+  private stream: MediaStream | null = null;
 
   async startRecording() {
     if (this.recorder !== null && this.recorder.state == "paused") {
       this.resume();
       return;
     }
-    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-    this.recorder = new MediaRecorder(stream);
+    this.stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    this.recorder = new MediaRecorder(this.stream);
     this.addListeners();
     this.recorder.start();
   }
@@ -48,6 +49,14 @@ export class MicrophoneService {
       );
       if (this.recorder === null) reject("Recorder was not created");
       else this.recorder.stop();
+      this.recorder = null;
+      if (this.stream === null) reject("Stream was not created");
+      else {
+        for (const track of this.stream.getTracks()) {
+          track.stop();
+        }
+      }
+      this.stream = null;
     });
   }
 

--- a/packages/studio-web/src/app/upload/upload.component.ts
+++ b/packages/studio-web/src/app/upload/upload.component.ts
@@ -231,6 +231,9 @@ Please check it to make sure all words are spelled out completely, e.g. write "4
   }
 
   async startRecording() {
+    if (this.recording)
+      // Not sure why the button stays clickable, but oh well
+      return;
     try {
       this.starting_to_record = true;
       await this.microphoneService.startRecording();


### PR DESCRIPTION
Previously the browser tab looked as if we were still recording.  We don't want the user to think we are spying on them!