### PR TITLE
feat: increase the text file size limits

### DIFF
--- a/packages/studio-web/src/app/upload/upload.component.ts
+++ b/packages/studio-web/src/app/upload/upload.component.ts
@@ -70,8 +70,8 @@ export class UploadComponent implements OnDestroy, OnInit {
   contactLink = environment.packageJson.contact;
   progressMode: ProgressBarMode = "indeterminate";
   progressValue = 0;
-  maxTxtSizeKB = 10; // Max 10 KB plain text file size
-  maxRasSizeKB = 20; // Max 20 KB .readalong XML text size
+  maxTxtSizeKB = 30; // Max 30 KB plain text file size
+  maxRasSizeKB = 60; // Max 60 KB .readalong XML text size
   @ViewChild("textInputElement") textInputElement: ElementRef;
   @Output() stepChange = new EventEmitter<any[]>();
   public uploadFormGroup = this._formBuilder.group({


### PR DESCRIPTION
Since we are monitoring backend use on heroku, we can increase the text file size limit and adjust if something goes wrong. It will be convenient to be able to process larger files on the web app.