### PR TITLE
Tonnerre de Brest! Correct the NPM packaging to work outside of this repo!

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14408,9 +14408,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001472",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001472.tgz",
-      "integrity": "sha512-xWC/0+hHHQgj3/vrKYY0AAzeIUgr7L9wlELIcAvZdDUHlhL/kNxMdnQLOSOQfP8R51ZzPhmHdyMkI0MMpmxCfg==",
+      "version": "1.0.30001606",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001606.tgz",
+      "integrity": "sha512-LPbwnW4vfpJId225pwjZJOgX1m9sGfbw/RKJvw/t0QhYOOaTXHvkjVGFGPpvwEzufrjvTlsULnVTxdy4/6cqkg==",
       "dev": true,
       "funding": [
         {
@@ -31634,9 +31634,9 @@
       }
     },
     "node_modules/rxjs": {
-      "version": "7.5.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
-      "integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -35362,9 +35362,9 @@
       }
     },
     "node_modules/zone.js": {
-      "version": "0.11.8",
-      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.11.8.tgz",
-      "integrity": "sha512-82bctBg2hKcEJ21humWIkXRlLBBmrc3nN7DFh5LGGhcyycO2S7FN8NmdvlcKaGFDNVL4/9kFLmwmInTavdJERA==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.12.0.tgz",
+      "integrity": "sha512-XtC+I5dXU14HrzidAKBNMqneIVUykLEAA1x+v4KVrd6AUPWlwYORF8KgsVqvgdHiKZ4BkxxjvYi/ksEixTPR0Q==",
       "dependencies": {
         "tslib": "^2.3.0"
       }
@@ -35385,9 +35385,25 @@
         "zone.js": "^0.11.8"
       }
     },
+    "packages/angular-demo/node_modules/rxjs": {
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
+      "integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "packages/angular-demo/node_modules/zone.js": {
+      "version": "0.11.8",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.11.8.tgz",
+      "integrity": "sha512-82bctBg2hKcEJ21humWIkXRlLBBmrc3nN7DFh5LGGhcyycO2S7FN8NmdvlcKaGFDNVL4/9kFLmwmInTavdJERA==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
     "packages/ngx-web-component": {
       "name": "@readalongs/ngx-web-component",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "devDependencies": {
         "@angular-devkit/architect": "^0.1501.6",
         "@angular-devkit/build-angular": "^15.2.4",
@@ -35403,9 +35419,9 @@
         "@angular/platform-browser": "^15.2.4",
         "@angular/platform-browser-dynamic": "^15.2.4",
         "@angular/router": "^15.2.4",
-        "rxjs": "~7.5.0",
+        "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
-        "zone.js": "^0.11.8"
+        "zone.js": "~0.12.0"
       }
     },
     "packages/studio-web": {
@@ -35430,13 +35446,13 @@
         "jszip": "^3.10.1",
         "mime": "^4.0.1",
         "ngx-toastr": "^16.1.0",
-        "rxjs": "~7.5.0",
+        "rxjs": "~7.8.0",
         "shepherd.js": "^11.0.1",
         "soundswallower": "^0.6.3",
         "standardized-audio-context": "^25.3.41",
         "tslib": "^2.3.0",
         "unidecode": "^1.0.1",
-        "zone.js": "^0.11.8"
+        "zone.js": "~0.12.0"
       },
       "devDependencies": {
         "@angular-builders/custom-webpack": "^15.0.0",
@@ -35554,12 +35570,12 @@
     },
     "packages/web-component": {
       "name": "@readalongs/web-component",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "audio-recorder-polyfill": "^0.4.1",
         "howler": "^2.2.3",
-        "rxjs": "^6.6.7"
+        "rxjs": ">=6.6.7"
       },
       "devDependencies": {
         "@stencil/angular-output-target": "^0.4.0",
@@ -35726,17 +35742,6 @@
         "node": ">= 10"
       }
     },
-    "packages/web-component/node_modules/rxjs": {
-      "version": "6.6.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
-      "dependencies": {
-        "tslib": "^1.9.0"
-      },
-      "engines": {
-        "npm": ">=2.0.0"
-      }
-    },
     "packages/web-component/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -35748,11 +35753,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "packages/web-component/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     }
   },
   "dependencies": {
@@ -44608,7 +44608,7 @@
         "cypress": "^12.17.4",
         "howler": "^2.2.3",
         "jest-cli": "^27.5.1",
-        "rxjs": "^6.6.7",
+        "rxjs": ">=6.6.7",
         "sirv-cli": "^1.0.14",
         "wait-on": "^6.0.1",
         "webpack": "^5.77.0",
@@ -44731,14 +44731,6 @@
             "react-is": "^17.0.1"
           }
         },
-        "rxjs": {
-          "version": "6.6.7",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-          "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
-          "requires": {
-            "tslib": "^1.9.0"
-          }
-        },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -44747,11 +44739,6 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
-        },
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -45985,6 +45972,24 @@
         "rxjs": "~7.5.0",
         "tslib": "^2.3.0",
         "zone.js": "^0.11.8"
+      },
+      "dependencies": {
+        "rxjs": {
+          "version": "7.5.7",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
+          "integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "zone.js": {
+          "version": "0.11.8",
+          "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.11.8.tgz",
+          "integrity": "sha512-82bctBg2hKcEJ21humWIkXRlLBBmrc3nN7DFh5LGGhcyycO2S7FN8NmdvlcKaGFDNVL4/9kFLmwmInTavdJERA==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        }
       }
     },
     "ansi-colors": {
@@ -46843,9 +46848,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001472",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001472.tgz",
-      "integrity": "sha512-xWC/0+hHHQgj3/vrKYY0AAzeIUgr7L9wlELIcAvZdDUHlhL/kNxMdnQLOSOQfP8R51ZzPhmHdyMkI0MMpmxCfg==",
+      "version": "1.0.30001606",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001606.tgz",
+      "integrity": "sha512-LPbwnW4vfpJId225pwjZJOgX1m9sGfbw/RKJvw/t0QhYOOaTXHvkjVGFGPpvwEzufrjvTlsULnVTxdy4/6cqkg==",
       "dev": true
     },
     "caseless": {
@@ -59470,7 +59475,7 @@
         "karma-jasmine-html-reporter": "~1.7.0",
         "mime": "^4.0.1",
         "ngx-toastr": "^16.1.0",
-        "rxjs": "~7.5.0",
+        "rxjs": "~7.8.0",
         "shepherd.js": "^11.0.1",
         "soundswallower": "^0.6.3",
         "standardized-audio-context": "^25.3.41",
@@ -59478,7 +59483,7 @@
         "typescript": "^4.9.5",
         "unidecode": "^1.0.1",
         "webpack": "^5.77.0",
-        "zone.js": "^0.11.8"
+        "zone.js": "~0.12.0"
       },
       "dependencies": {
         "@angular/cdk": {
@@ -59885,9 +59890,9 @@
       }
     },
     "rxjs": {
-      "version": "7.5.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
-      "integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "requires": {
         "tslib": "^2.1.0"
       }
@@ -62656,9 +62661,9 @@
       "dev": true
     },
     "zone.js": {
-      "version": "0.11.8",
-      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.11.8.tgz",
-      "integrity": "sha512-82bctBg2hKcEJ21humWIkXRlLBBmrc3nN7DFh5LGGhcyycO2S7FN8NmdvlcKaGFDNVL4/9kFLmwmInTavdJERA==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.12.0.tgz",
+      "integrity": "sha512-XtC+I5dXU14HrzidAKBNMqneIVUykLEAA1x+v4KVrd6AUPWlwYORF8KgsVqvgdHiKZ4BkxxjvYi/ksEixTPR0Q==",
       "requires": {
         "tslib": "^2.3.0"
       }

--- a/packages/angular-demo/src/assets/ej-fra.readalong
+++ b/packages/angular-demo/src/assets/ej-fra.readalong
@@ -6,7 +6,7 @@
     <text xml:lang="fra" id="t0">
         <body id="t0b0">
             <div type="page" id="t0b0d0">
-            <graphic url="http://localhost:5000/ej-fra/avatar.png" id="t0b0d0graphic0"/>
+            <graphic url="avatar.png" id="t0b0d0graphic0"/>
                 <p id="t0b0d0p0">
                     <s id="t0b0d0p0s0"><w id="t0b0d0p0s0w0" time="0.455" dur="1.165">Bonjour</w>.</s>
                     <s id="t0b0d0p0s1"><w id="t0b0d0p0s1w0" time="1.620" dur="0.070">Je</w> <w id="t0b0d0p0s1w1" time="1.690" dur="0.070">m</w>'<w id="t0b0d0p0s1w2" time="1.760" dur="0.240">appelle</w> <w id="t0b0d0p0s1w3" time="2.000" dur="0.220">Éric</w> <w id="t0b0d0p0s1w4" time="2.220" dur="0.370">Joanis</w>.</s>

--- a/packages/ngx-web-component/package.json
+++ b/packages/ngx-web-component/package.json
@@ -11,9 +11,9 @@
     "@angular/platform-browser": "^15.2.4",
     "@angular/platform-browser-dynamic": "^15.2.4",
     "@angular/router": "^15.2.4",
-    "rxjs": "~7.5.0",
+    "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
-    "zone.js": "^0.11.8"
+    "zone.js": "~0.12.0"
   },
   "private": false,
   "nx": {

--- a/packages/studio-web/package.json
+++ b/packages/studio-web/package.json
@@ -50,13 +50,13 @@
     "jszip": "^3.10.1",
     "mime": "^4.0.1",
     "ngx-toastr": "^16.1.0",
-    "rxjs": "~7.5.0",
+    "rxjs": "~7.8.0",
     "shepherd.js": "^11.0.1",
     "soundswallower": "^0.6.3",
     "standardized-audio-context": "^25.3.41",
     "tslib": "^2.3.0",
     "unidecode": "^1.0.1",
-    "zone.js": "^0.11.8"
+    "zone.js": "~0.12.0"
   },
   "singleFileBundleVersion": "1.2.1",
   "singleFileBundleTimestamp": "2024-04-02+15-07-59"

--- a/packages/web-component/package.json
+++ b/packages/web-component/package.json
@@ -12,7 +12,8 @@
   "unpkg": "dist/bundle.js",
   "private": false,
   "files": [
-    "dist/"
+    "dist/",
+    "loader/"
   ],
   "scripts": {
     "build": "stencil build --docs",

--- a/packages/web-component/package.json
+++ b/packages/web-component/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "audio-recorder-polyfill": "^0.4.1",
     "howler": "^2.2.3",
-    "rxjs": "^6.6.7"
+    "rxjs": ">=6.6.7"
   },
   "devDependencies": {
     "@stencil/angular-output-target": "^0.4.0",


### PR DESCRIPTION
Fixes #259.

Angular 15's `ng new` will give you rxjs `~7.8.0` which is incompatible with the `~7.5.0` we had.  Likewise it gives you zone.js `~0.12.0` which is incompatible with `~0.11.8`.  There's probably no good reason for us to care about these precise versions, but oh well.

More importantly we need to install the `loader` folder alongside `dist`  in the `web-component` for NPM or else we simply can't load the package (we didn't notice this because we were pointing to the built distribution which includes this folder even if the published one to NPM doesn't - I would love to blame this on `nx` but I can't because if we used good old `npm link` we'd have the same problem - NPM is the problem - it is always the problem)

Also make sure the `angular-demo` shows a sea captain.
