### PR TITLE
fix(ci): the bundle is not actually stable, cannot validate with cmp

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,9 +33,6 @@ jobs:
           npx nx build web-component
           npx nx bundle web-component
           npx nx build ngx-web-component
-      - name: Check that the web-component bundle was up to date
-        run: |
-          if git status --porcelain | grep packages/studio-web/src/assets/; then echo ERROR: The web-component bundle is out of date. Please run \"npx nx bundle web-component\" and commit the results, then update the tag and try again.; false; fi
       - name: Publish web-component to npmjs
         run: |
           cd dist/packages/web-component && npm publish --access=public


### PR DESCRIPTION
git status --porcelain demands exact equality of the committed bundle and the one built in CI, but the minification and optimization process is not completely deterministic, so it's not a reliable test.

We don't actually use the bundle in the published packages, and we in fact rebuild the bundle automatically as part of the publish.yml workflow that deploys to gh-pages and production, so this is not useful test at all!

