### PR TITLE
fix(web-c): better Fr trans for "upload an image for this page"

### DIFF
--- a/packages/web-component/src/i18n/messages.fra.json
+++ b/packages/web-component/src/i18n/messages.fra.json
@@ -8,7 +8,7 @@
     "alignment-error": "Erreur: aucun alignement n'a été trouvé.",
     "loading": "Chargement en cours",
     "line-placeholder": "Écrivez votre texte ici",
-    "upload-image": "Téléverser charger une image pour cette page",
+    "upload-image": "Ajouter une image à cette page",
     "choose-file": "Choisir un fichier",
     "play-tooltip": "Écouter/mettre en pause l'enregistrement",
     "rewind-tooltip": "Reculer de 5 secondes",


### PR DESCRIPTION
"Téléverser charger" was just wrong, but I completely rewrote the message to be clearer and closer to what it means rather than to the Enlish text it was translated from.

<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Tiny translation fix in the French

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->



### Feedback sought? <!-- What should reviewers focus on in particular? -->



### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

low

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

n/a

### How to test? <!-- Explain how reviewers should test this PR. -->

choose the Web-C language as French 

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

not just for this, but it'll come with the minor bump already scheduled.

<!-- Add any other relevant information here -->
