### PR TITLE
fix: allows the ability to highlight the word using the progress bar

### DIFF
--- a/packages/web-component/cypress/e2e/basic.cy.js
+++ b/packages/web-component/cypress/e2e/basic.cy.js
@@ -20,30 +20,27 @@ context("The Readalong Component", () => {
   });
 
   it("should play the entire ReadAlong", () => {
-    cy.wait("@text");
-    cy.wait("@audio");
+    cy.wait(["@text", "@audio"]);
 
     cy.readalong().within(() => {
-      cy.get("[data-cy=play-button]").click();
+      cy.playReadAlong();
       cy.wait(FOR_ERIC_TO_TALK_A_BIT);
       cy.get("[data-cy=stop-button]").click();
     });
   });
 
   it("should play a single word when clicked", () => {
-    cy.wait("@text");
-    cy.wait("@audio");
+    cy.wait(["@text", "@audio"]);
 
     cy.readalong().contains("technologies").click();
   });
 
   describe("the progress bar", () => {
     it("should skip ahead when clicked", () => {
-      cy.wait("@text");
-      cy.wait("@audio");
+      cy.wait(["@text", "@audio"]);
 
       cy.readalong().within(() => {
-        cy.get("[data-cy=play-button]").click();
+        cy.playReadAlong();
         cy.get("[data-cy=page-count__current]")
           .filter("*:visible")
           .invoke("text")
@@ -72,6 +69,8 @@ context("The Readalong Component", () => {
       cy.wait("@text");
       cy.wait("@audio").then(() => {
         cy.readalong().within(() => {
+          //wait for initialization process to be completed
+          cy.get("[data-cy=play-button]").should("be.enabled");
           //word corpus and robuste should hidden
           cy.get("#t0b0d1p0s2w1").should("not.be.visible");
           cy.get("#t0b0d1p1s0w14").should("not.be.visible");
@@ -85,9 +84,9 @@ context("The Readalong Component", () => {
                 el.height() * 0.5,
               );
             });
-          //word corpus and robuste should hidden
-          cy.get("#t0b0d1p0s2w1").should("not.be.visible");
-          cy.get("#t0b0d1p1s0w14").should("not.be.visible");
+          //word corpus and robuste should now be visible
+          cy.get("#t0b0d1p0s2w1").should("be.visible");
+          cy.get("#t0b0d1p1s0w14").should("be.visible");
           cy.get("[data-cy=play-button]")
             .click()
             .then(() => {
@@ -95,7 +94,7 @@ context("The Readalong Component", () => {
               //word corpus and robuste should now visible
               cy.get("#t0b0d1p0s2w1").should("be.visible");
               cy.get("#t0b0d1p1s0w14").should("be.visible");
-              cy.get("[data-cy=play-button]").click();
+              cy.playReadAlong();
             });
         });
       });

--- a/packages/web-component/cypress/e2e/customizations.cy.js
+++ b/packages/web-component/cypress/e2e/customizations.cy.js
@@ -6,8 +6,7 @@ context("Testing creator enabled settings", () => {
 
   it("testing creator enforced hiding of translation at load time ", function () {
     cy.visit("/ej-fra/index-translated-no-display.html");
-    cy.wait("@text");
-    cy.wait("@audio");
+    cy.wait(["@text", "@audio"]);
     cy.readalong().within(() => {
       cy.get("#t0b0d0p0s0w0").should("be.visible");
       cy.get("#t0b0d0p0s0trtext0").should("not.be.visible");
@@ -17,8 +16,7 @@ context("Testing creator enabled settings", () => {
 
   it("testing creator allows showing of translation at load time ", function () {
     cy.visit("/ej-fra/index-translated.html");
-    cy.wait("@text");
-    cy.wait("@audio");
+    cy.wait(["@text", "@audio"]);
     cy.readalong().within(() => {
       cy.get("#t0b0d0p0s0w0").should("be.visible");
       cy.get("#t0b0d0p0s0trtext0").should("be.visible");
@@ -28,10 +26,9 @@ context("Testing creator enabled settings", () => {
 
   it("testing creator enabling auto pause ", function () {
     cy.visit("/ej-fra/index-with-auto-pause.html");
-    cy.wait("@text");
-    cy.wait("@audio");
+    cy.wait(["@text", "@audio"]);
     cy.readalong().within(() => {
-      cy.get("[data-cy=play-button]").click();
+      cy.playReadAlong();
       cy.wait(12000); //wait for the last word of the first page (at 6.4) + ~5 sec
 
       cy.get("#t0b0d0p0s2w15")

--- a/packages/web-component/cypress/e2e/embedded.cy.js
+++ b/packages/web-component/cypress/e2e/embedded.cy.js
@@ -19,7 +19,7 @@ context("The Readalong Component", () => {
     cy.wait(EXPECTED_LOADING_TIME);
 
     cy.readalong().within(() => {
-      cy.get("[data-cy=play-button]").click();
+      cy.playReadAlong();
       cy.wait(FOR_ERIC_TO_TALK_A_BIT);
       cy.get("[data-cy=stop-button]").click();
     });
@@ -36,7 +36,7 @@ context("The Readalong Component", () => {
       cy.wait(EXPECTED_LOADING_TIME);
 
       cy.readalong().within(() => {
-        cy.get("[data-cy=play-button]").click();
+        cy.playReadAlong();
         cy.get("[data-cy=page-count__current]")
           .filter("*:visible")
           .invoke("text")

--- a/packages/web-component/cypress/e2e/settings.cy.js
+++ b/packages/web-component/cypress/e2e/settings.cy.js
@@ -4,8 +4,7 @@ context("Testing end user enabled settings", () => {
     cy.intercept(/\.m4a/).as("audio");
 
     cy.visit("/ej-fra/");
-    cy.wait("@text");
-    cy.wait("@audio");
+    cy.wait(["@text", "@audio"]);
   });
   it("can open the settings", () => {
     cy.readalong().within(() => {
@@ -54,7 +53,7 @@ context("Testing end user enabled settings", () => {
       cy.get("[data-test-id=settings-pause-timeout]").should("not.exist");
       cy.get("[data-test-id=settings-close-button]").click();
       cy.get("[data-test-id=settings]").should("not.exist");
-      cy.get("[data-cy=play-button]").click();
+      cy.playReadAlong();
       cy.wait(7000); //6740 timestamp of the first word on second page
       cy.get("#t0b0d1p0s0w0").should("not.be.visible");
 

--- a/packages/web-component/cypress/support/commands.js
+++ b/packages/web-component/cypress/support/commands.js
@@ -28,3 +28,9 @@ Cypress.Commands.add("readalong", () => {
 Cypress.Commands.add("readalongElement", () => {
   return cy.get("read-along").first();
 });
+
+Cypress.Commands.add("playReadAlong", () => {
+  cy.get("[data-cy=play-button]", { timeout: 10000 })
+    .should("be.enabled")
+    .click();
+});

--- a/packages/web-component/src/components/read-along-component/read-along.tsx
+++ b/packages/web-component/src/components/read-along-component/read-along.tsx
@@ -450,7 +450,7 @@ export class ReadAlongComponent {
    */
   play() {
     //do not attempt to play if sprites are not initialized
-    if (this.audio_howl_sprites == undefined) return;
+    if (this.audio_howl_sprites === undefined) return;
     this.playing = true;
     // If already playing once, continue playing
     if (this.play_id !== undefined) {
@@ -1122,7 +1122,7 @@ export class ReadAlongComponent {
         }
         // Turn tag to query
         let query = this.tagToQuery(el_tag);
-        if (query == undefined) return; // not go any further if tag does not exist in the DOM
+        if (query === undefined) return; // not go any further if tag does not exist in the DOM
         // select the element with that tag
         let query_el: HTMLElement = this.el.shadowRoot.querySelector(query);
         // Remove all elements with reading class
@@ -1215,7 +1215,7 @@ export class ReadAlongComponent {
     if (this.audio_howl_sprites === undefined) return false;
 
     //not ready if
-    if (this.audio_howl_sprites.sound == undefined) return false;
+    if (this.audio_howl_sprites.sound === undefined) return false;
 
     return true; //it is ready
   }

--- a/packages/web-component/src/components/read-along-component/read-along.tsx
+++ b/packages/web-component/src/components/read-along-component/read-along.tsx
@@ -10,6 +10,7 @@ import {
   Method,
   Prop,
   State,
+  Watch,
 } from "@stencil/core";
 
 import {
@@ -201,18 +202,20 @@ export class ReadAlongComponent {
   finalTaggedWord: string;
   @State() settingsVisible: boolean = false;
   @State() userPreferencesDirty: boolean = false;
+  @Watch("audio_howl_sprites")
   /************
    *  LISTENERS  *
    ************/
-
   @Listen("wheel", { target: "window" })
   wheelHandler(event: MouseEvent): void {
     // only show guide if there is an actual highlighted element
     if (this.el.shadowRoot.querySelector(".reading")) {
       if (
-        event["path"][0].classList.contains("sentence__word") ||
-        event["path"][0].classList.contains("sentence__container") ||
-        event["path"][0].classList.contains("sentence")
+        event["path"] &&
+        event["path"].length > 0 &&
+        (event["path"][0].classList.contains("sentence__word") ||
+          event["path"][0].classList.contains("sentence__container") ||
+          event["path"][0].classList.contains("sentence"))
       ) {
         if (this.autoScroll) {
           let reading_el: HTMLElement =
@@ -392,7 +395,8 @@ export class ReadAlongComponent {
       this.play();
       this.pause();
     }
-    this.autoScroll = false;
+    //allow display to bring the selected portion into view
+    this.autoScroll = true;
     seek = seek / 1000;
     this.audio_howl_sprites.goTo(this.play_id, seek);
     setTimeout(() => (this.autoScroll = true), 100);
@@ -432,8 +436,10 @@ export class ReadAlongComponent {
    * Pause audio.
    */
   pause(): void {
-    this.playing = false;
-    this.audio_howl_sprites.pause();
+    if (this.playing) {
+      this.playing = false;
+      this.audio_howl_sprites.pause();
+    }
   }
 
   /**
@@ -443,6 +449,8 @@ export class ReadAlongComponent {
    *
    */
   play() {
+    //do not attempt to play if sprites are not initialized
+    if (this.audio_howl_sprites == undefined) return;
     this.playing = true;
     // If already playing once, continue playing
     if (this.play_id !== undefined) {
@@ -476,6 +484,7 @@ export class ReadAlongComponent {
     if (this.audio_howl_sprites) {
       this.audio_howl_sprites.stop();
     }
+
     this.el.shadowRoot
       .querySelectorAll(".reading")
       .forEach((x) => x.classList.remove("reading"));
@@ -797,7 +806,8 @@ export class ReadAlongComponent {
     let inOverflowBelow =
       el_rect.top + el_rect.height > page_rect.top + page_rect.height;
     // element being read is above/behind of the words being viewed
-    let inOverflowAbove = el_rect.top + el_rect.height < 0;
+    //even if it is barely above the view
+    let inOverflowAbove = el_rect.top < page_rect.top;
 
     let intersectionObserver = new IntersectionObserver((entries) => {
       let [entry] = entries;
@@ -806,6 +816,8 @@ export class ReadAlongComponent {
           this.showGuide = false;
           this.autoScroll = true;
         }, 100);
+        // IT IS VISIBLE
+        inOverflowAbove = inOverflowBelow = false;
         intersectionObserver.unobserve(element);
       }
     });
@@ -1091,75 +1103,77 @@ export class ReadAlongComponent {
       .subscribe((el_tag) => {
         // Update the main reading tag subject
         this.reading$.next(el_tag);
-        // Only highlight when playing
-        if (this.playing) {
-          //if auto pause is active and not on last word of the read along pause the audio
-          if (
-            this.autoPauseAtEndOfPage &&
-            el_tag in this.endOfPageTags &&
-            this.finalTaggedWord !== el_tag
-          ) {
-            //clear previous timeout if active
-            if (this.autoPauseTimer) window.clearTimeout(this.autoPauseTimer);
-            //pause 25ms before end of word
-            this.autoPauseTimer = window.setTimeout(() => {
-              this.pause();
-            }, this.endOfPageTags[el_tag][1] - 25);
-          }
-          // Turn tag to query
-          let query = this.tagToQuery(el_tag);
-          // select the element with that tag
-          let query_el: HTMLElement = this.el.shadowRoot.querySelector(query);
-          // Remove all elements with reading class
-          this.el.shadowRoot
-            .querySelectorAll(".reading")
-            .forEach((x) => x.classList.remove("reading"));
-          // Add reading to the selected el
-          query_el.classList.add("reading");
+        //if stop
+        if (el_tag == "") return;
 
-          // Scroll horizontally (to different page) if needed
-          let current_page =
-            ReadAlongComponent._getSentenceContainerOfWord(query_el)
-              .parentElement.id;
+        //if auto pause is active and not on last word of the read along pause the audio
+        if (
+          this.playing &&
+          this.autoPauseAtEndOfPage &&
+          el_tag in this.endOfPageTags &&
+          this.finalTaggedWord !== el_tag
+        ) {
+          //clear previous timeout if active
+          if (this.autoPauseTimer) window.clearTimeout(this.autoPauseTimer);
+          //pause 25ms before end of word
+          this.autoPauseTimer = window.setTimeout(() => {
+            this.pause();
+          }, this.endOfPageTags[el_tag][1] - 25);
+        }
+        // Turn tag to query
+        let query = this.tagToQuery(el_tag);
+        if (query == undefined) return; // not go any further if tag does not exist in the DOM
+        // select the element with that tag
+        let query_el: HTMLElement = this.el.shadowRoot.querySelector(query);
+        // Remove all elements with reading class
+        this.el.shadowRoot
+          .querySelectorAll(".reading")
+          .forEach((x) => x.classList.remove("reading"));
+        // Add reading to the selected el
+        query_el.classList.add("reading");
 
-          if (current_page !== this.current_page) {
-            if (this.current_page !== undefined && !this.isScrolling) {
-              this.scrollToPage(current_page);
-            }
-            this.current_page = current_page;
+        // Scroll horizontally (to different page) if needed
+        let current_page =
+          ReadAlongComponent._getSentenceContainerOfWord(query_el).parentElement
+            .id;
+
+        if (current_page !== this.current_page) {
+          if (this.current_page !== undefined && !this.isScrolling) {
+            this.scrollToPage(current_page);
           }
-          const leftEdge =
-            Math.ceil(
-              this.el.shadowRoot
-                .querySelector(".pages__container")
-                .getBoundingClientRect().left,
-            ) + 1;
-          const pageLeftEdge = Math.ceil(
+          this.current_page = current_page;
+        }
+        const leftEdge =
+          Math.ceil(
             this.el.shadowRoot
-              .querySelector("#" + this.current_page)
+              .querySelector(".pages__container")
               .getBoundingClientRect().left,
-          );
+          ) + 1;
+        const pageLeftEdge = Math.ceil(
+          this.el.shadowRoot
+            .querySelector("#" + this.current_page)
+            .getBoundingClientRect().left,
+        );
 
-          //if the user has scrolled away from the from the current page bring them page
-          if (
-            query_el.getBoundingClientRect().left < 0 ||
-            pageLeftEdge !== leftEdge
-          ) {
-            if (!this.isScrolling) this.scrollToPage(current_page);
+        //if the user has scrolled away from the from the current page bring them page
+        if (
+          query_el.getBoundingClientRect().left < 0 ||
+          pageLeftEdge !== leftEdge
+        ) {
+          if (!this.isScrolling) this.scrollToPage(current_page);
+        }
+
+        // scroll vertically (through paragraph) if needed
+        if (this.inPageContentOverflow(query_el)) {
+          if (this.autoScroll) {
+            query_el.scrollIntoView({ block: "start", inline: "nearest" });
+            if (!this.isScrolling) this.scrollByHeight(query_el);
           }
-
-          // scroll vertically (through paragraph) if needed
-          if (this.inPageContentOverflow(query_el)) {
-            if (this.autoScroll) {
-              query_el.scrollIntoView({ block: "start", inline: "nearest" });
-              if (!this.isScrolling) this.scrollByHeight(query_el);
-            }
-          } // scroll horizontal (through paragraph) if needed
-          if (this.inParagraphContentOverflow(query_el)) {
-            if (this.autoScroll) {
-              query_el.scrollIntoView(false);
-              if (!this.isScrolling) this.scrollByWidth(query_el);
-            }
+        } // scroll horizontal (through paragraph) if needed
+        if (this.inParagraphContentOverflow(query_el)) {
+          if (this.autoScroll) {
+            query_el.scrollIntoView(false);
+            if (!this.isScrolling) this.scrollByWidth(query_el);
           }
         }
       });
@@ -1187,7 +1201,24 @@ export class ReadAlongComponent {
       this.latestTranslation = "";
     }
   }
+  /**
+   * Is the App ready to start playing
+   * This could be expressed as one line
+   * but because there are multiple states involved
+   * breaking it down to make it easier to track
+   */
+  isReadyToPlay(): boolean {
+    //not ready if still audio & alignment is not loaded
+    if (this.hasLoaded < 2) return false;
 
+    //not ready if
+    if (this.audio_howl_sprites === undefined) return false;
+
+    //not ready if
+    if (this.audio_howl_sprites.sound == undefined) return false;
+
+    return true; //it is ready
+  }
   /**********
    *  LANG  *
    **********/
@@ -1706,7 +1737,7 @@ export class ReadAlongComponent {
   PlayControl = (): Element => (
     <button
       data-cy="play-button"
-      disabled={this.hasLoaded < 2}
+      disabled={!this.isReadyToPlay()}
       aria-label="Play"
       title={this.getI18nString("play-tooltip")}
       onClick={() => {


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

- Allows the ability to highlight the words in the read-along using the progress bar, even if the audio is not currently playing
- Changes to the web-component tests to use a new state-sensitive custom command for play sequence. 

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->
Closes #266  #275 


### Feedback sought? <!-- What should reviewers focus on in particular? -->
Progress bar interaction, play/stop.


### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->
Low


### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->
Updates all web-components tests.


### How to test? <!-- Explain how reviewers should test this PR. -->
Clicking various locations on the progress bar, start/pause/stop a bunch of time 


### Confidence? <!-- How confident are you that these changes are ready to merge? -->
high


### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

<!-- Add any other relevant information here -->
