### PR TITLE
ci: delete PR previews when the PR is closed

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -7,6 +7,7 @@ on:
       - opened
       - reopened
       - synchronize
+      - closed
 jobs:
   deploy-preview:
     runs-on: ubuntu-latest
@@ -17,14 +18,17 @@ jobs:
         with:
           node-version: "20"
       - name: Install
+        if: github.event.action != 'closed'
         run: |
           npm install
       - name: Build web-component
+        if: github.event.action != 'closed'
         run: |
           npx nx build web-component
           # create the bundles required for studio-web
           npx nx bundle web-component
       - name: Build
+        if: github.event.action != 'closed'
         run: |
           npx nx build studio-web --base-href=/pr-preview/pr-${{github.event.number}}/ --configuration=production
           npx nx build studio-web --base-href=/pr-preview/pr-${{github.event.number}}/ --configuration=production --localize=fr --deleteOutputPath=false


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Auto-clean up PR previews

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

Fixes #285

### Feedback sought? <!-- What should reviewers focus on in particular? -->

rubber stamping

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

normal

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

n/a, the test will be looking at what happens when we merge this PR in.

### How to test? <!-- Explain how reviewers should test this PR. -->

merge the PR. Kinda late, but it's a trivial PR

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high, I followed the simple instructions at https://github.com/marketplace/actions/deploy-pr-preview

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

<!-- Add any other relevant information here -->
