### PR TITLE
Fix the relative links in the READMEs published to npmjs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,10 @@ jobs:
           npx nx build web-component
           npx nx bundle web-component
           npx nx build ngx-web-component
+      - name: Fix the relative URLs in the READMEs to work on npmjs
+        run: |
+          sed -i 's/(\.\.\/web-component)/(web-component)/g' dist/packages/ngx-web-component/README.md
+          sed -i 's/(test-data\//(https:\/\/github.com\/ReadAlongs\/Studio-Web\/blob\/${{ github.ref_name }}\/packages\/web-component\/test-data\//g' dist/packages/web-component/README.md
       - name: Publish web-component to npmjs
         run: |
           cd dist/packages/web-component && npm publish --access=public


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Relative links in our READMEs work correctly on GitHub, but not on npmjs. And unfortunately, there isn't a solution that will work on both, because github does some relative link rewrite on render than npmjs does not, and making it work on one site breaks it on the other.

So I decided to go for an automated post-edit option in our release workflow. It's not universal: if we add other relative links, we'll likely have to modify the release workflow again. But it's effective.

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

Fixes #311

### Feedback sought? <!-- What should reviewers focus on in particular? -->

sanity checking

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

before the next minor release

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

can't automate, but I exercised the code by pushing test tags (which I'll delete shortly)

### How to test? <!-- Explain how reviewers should test this PR. -->

See workflow https://github.com/ReadAlongs/Studio-Web/actions/runs/9451153166/job/26031422594 displaying the links correctly in the "show the updated readmes" step.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

High

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

patch bump, since we can't update the readme for a version that's already published

We should publish the next patch soonish, so that our default version on npmjs has working links, but it's not urgent

<!-- Add any other relevant information here -->
