### PR TITLE
docs: add quick links to the editor and the documentation

### DIFF
--- a/packages/studio-web/src/app/studio/studio.component.html
+++ b/packages/studio-web/src/app/studio/studio.component.html
@@ -14,18 +14,44 @@
           <h1 i18n="Welcome message for app" id="welcome-header">
             Welcome to ReadAlong Studio
           </h1>
-          <p i18n="Description of app">
-            This is a tool to help you make your own interactive 'readalong'
-            that highlights words as they are spoken. Have a look at
-            <a
-              href="https://www.eastcree.org/cree/en/lessons/read-along/northern-dialect/when-the-beaver-had-a-round-tail/"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <mat-icon inline style="vertical-align: middle">launch</mat-icon>
-              this example in East Cree</a
-            >
-            to get a better idea of what these are.
+          <p>
+            <span i18n="Description of app">
+              This is a tool to help you make your own interactive 'readalong'
+              that highlights words as they are spoken. Have a look at
+              <a
+                href="https://www.eastcree.org/cree/en/lessons/read-along/northern-dialect/when-the-beaver-had-a-round-tail/"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <mat-icon inline style="vertical-align: middle"
+                  >launch</mat-icon
+                >
+                this example in East Cree</a
+              >
+              to get a better idea of what these are.
+            </span>
+            <span i18n="editor link">
+              <mat-icon inline style="vertical-align: middle">
+                new_releases
+              </mat-icon>
+              Try the new
+              <a routerLink="/editor" target="_blank" rel="noopener noreferrer">
+                <mat-icon inline style="vertical-align: middle">launch</mat-icon
+                >&nbsp;ReadAlong Studio Editor</a
+              >.
+            </span>
+            <span i18n="docs link">
+              <mat-icon inline style="vertical-align: middle">
+                new_releases </mat-icon
+              >&nbsp;<a
+                href="https://readalongs.github.io/Studio/latest/web-app/"
+                target="_blank"
+                rel="noopener noreferrer"
+                ><mat-icon inline style="vertical-align: middle"
+                  >launch</mat-icon
+                >&nbsp;Documentation</a
+              >
+            </span>
           </p>
           <p i18n="Get started">
             To get started making your own, read our

--- a/packages/studio-web/src/i18n/messages.es.json
+++ b/packages/studio-web/src/i18n/messages.es.json
@@ -89,6 +89,8 @@
     "8428348909593474745": "Paso 1",
     "7458890725604973091": "Bienvenido al Studio de ReadAlong",
     "3614618598824071164": " Esta es una herramienta diseñada para ayudarlo a crear su propio 'readalong' que resalta las palabras a medida que se pronuncian. Puede ver {$START_LINK}{$START_TAG_MAT_ICON}launch{$CLOSE_TAG_MAT_ICON} este ejemplo en el idioma cree oriental{$CLOSE_LINK} para tener una mejor idea de qué es un 'readalong'. ",
+    "7459555979295642756": "{$START_TAG_MAT_ICON} new_releases {$CLOSE_TAG_MAT_ICON} Prueba el nuevo {$START_LINK}{$START_TAG_MAT_ICON}launch{$CLOSE_TAG_MAT_ICON} Editor del Studio de ReadAlong{$CLOSE_LINK}. ",
+    "1380235932960787950": "{$START_TAG_MAT_ICON} new_releases {$CLOSE_TAG_MAT_ICON} {$START_LINK}{$START_TAG_MAT_ICON}launch{$CLOSE_TAG_MAT_ICON} Documentación (en inglés){$CLOSE_LINK}",
     "11480612528390167": "Para empezar a crear su propio 'readalong', lea nuestra {$START_LINK}política de privacidad y soberanía de los datos{$CLOSE_LINK} y luego siga el tour del sitio haciendo clic en el botón «Siga el tour» y siguiendo los pasos descritos aquí debajo. ",
     "3943314737845757694": "Paso 2",
     "1021386634200142621": "Studio de ReadAlong para Narraciones Interactivas",

--- a/packages/studio-web/src/i18n/messages.fr.json
+++ b/packages/studio-web/src/i18n/messages.fr.json
@@ -89,6 +89,8 @@
     "8428348909593474745": "Étape 1",
     "7458890725604973091": " Bienvenue au Studio ReadAlong ",
     "3614618598824071164": " Cet outil vous aidera à créer une page interactive de lecture accompagnée, sur laquelle les mots sont surlignés lorsqu'ils sont lus à voix haute. Jetez un coup d'œil à {$START_LINK}{$START_TAG_MAT_ICON}launch{$CLOSE_TAG_MAT_ICON} cet exemple en cri de l'Est{$CLOSE_LINK} pour mieux comprendre le concept. ",
+    "7459555979295642756": "{$START_TAG_MAT_ICON} new_releases {$CLOSE_TAG_MAT_ICON} Essayer le nouvel {$START_LINK}{$START_TAG_MAT_ICON}launch{$CLOSE_TAG_MAT_ICON} Éditeur du Studio ReadAlong{$CLOSE_LINK}. ",
+    "1380235932960787950": "{$START_TAG_MAT_ICON} new_releases {$CLOSE_TAG_MAT_ICON} {$START_LINK}{$START_TAG_MAT_ICON}launch{$CLOSE_TAG_MAT_ICON} Documentation (en anglais){$CLOSE_LINK}",
     "11480612528390167": " Avant de commencer à en faire vous-même, veuillez lire notre {$START_LINK}politique de vie privée et de souveraineté des données{$CLOSE_LINK}, faites une visite guidée en cliquant sur le bouton « Visite guidée » puis suivez les étapes ci-dessous. ",
     "3943314737845757694": "Étape 2",
     "1021386634200142621": "Studio ReadAlong pour contes interactifs",

--- a/packages/studio-web/src/i18n/messages.json
+++ b/packages/studio-web/src/i18n/messages.json
@@ -89,6 +89,8 @@
     "8428348909593474745": "Step 1",
     "7458890725604973091": " Welcome to ReadAlong Studio ",
     "3614618598824071164": " This is a tool to help you make your own interactive 'readalong' that highlights words as they are spoken. Have a look at {$START_LINK}{$START_TAG_MAT_ICON}launch{$CLOSE_TAG_MAT_ICON} this example in East Cree{$CLOSE_LINK} to get a better idea of what these are. ",
+    "7459555979295642756": "{$START_TAG_MAT_ICON} new_releases {$CLOSE_TAG_MAT_ICON} Try the new {$START_LINK}{$START_TAG_MAT_ICON}launch{$CLOSE_TAG_MAT_ICON} ReadAlong Studio Editor{$CLOSE_LINK}. ",
+    "1380235932960787950": "{$START_TAG_MAT_ICON} new_releases {$CLOSE_TAG_MAT_ICON} {$START_LINK}{$START_TAG_MAT_ICON}launch{$CLOSE_TAG_MAT_ICON} Documentation{$CLOSE_LINK}",
     "11480612528390167": " To get started making your own, read our {$START_LINK}privacy and data sovereignty policy{$CLOSE_LINK}, then take a tour by clicking on the tour button below, and follow the steps below. ",
     "3943314737845757694": "Step 2",
     "1021386634200142621": "ReadAlong-Studio for Interactive Storytelling",


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Minimal link option pointing to Editor and docs, not the way we will want them for good, but while we want for Aidan's better solution to be fixed.

I suggest merging this once Del has fixed the download output from the editor, if you're OK with this format.