### PR TITLE
fix: reduce how much real estate is spent on studio&editor headers

### DIFF
--- a/packages/studio-web/src/app/editor/editor.component.html
+++ b/packages/studio-web/src/app/editor/editor.component.html
@@ -1,8 +1,8 @@
 <section class="container mt-1"></section>
 <section id="editor">
-  <div class="container mb-2 mt-5">
-    <div class="row justify-content-center mb-5">
-      <div class="col-6">
+  <div class="container mt-4">
+    <div class="row mb-3">
+      <div class="col-8">
         <h1 i18n="Welcome message for app editor" id="welcome-header">
           Welcome to the ReadAlong Studio Editor
         </h1>
@@ -10,10 +10,10 @@
           This is a tool to help you edit your existing 'readalongs'. To get
           started, click on the tour button below, and follow the steps.
         </p>
-        <div class="row mt-5 justify-content-center">
+        <div class="row mt-0 justify-content-center">
           <button
             i18n="Take the tour"
-            class="mb-4 col center text-center plausible-event-name=Tour"
+            class="mb-4 col-9 center text-center plausible-event-name=Tour"
             mat-raised-button
             color="primary"
             (click)="startTour()"
@@ -22,7 +22,7 @@
           </button>
         </div>
       </div>
-      <div class="col-6" *ngIf="editorService.uploadFormGroup.valid">
+      <div class="col-4" *ngIf="editorService.uploadFormGroup.valid">
         <ras-shared-download
           (downloadButtonClicked)="download($event)"
         ></ras-shared-download>

--- a/packages/studio-web/src/app/studio/studio.component.html
+++ b/packages/studio-web/src/app/studio/studio.component.html
@@ -9,40 +9,36 @@
     label="Step 1"
   >
     <section>
-      <div class="container mb-2">
-        <div class="row justify-content-center mb-5">
-          <div class="col-6">
-            <p i18n="Description of app">
-              This is a tool to help you make your own interactive 'readalong'
-              that highlights words as they are spoken. Have a look at
-              <a
-                href="https://www.eastcree.org/cree/en/lessons/read-along/northern-dialect/when-the-beaver-had-a-round-tail/"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                <mat-icon inline style="vertical-align: middle"
-                  >launch</mat-icon
-                >
-                this example in East Cree</a
-              >
-              to get a better idea of what these are.
-            </p>
-            <p i18n="Get started">
-              To get started making your own, click on the tour button below,
-              and follow the steps.
-            </p>
-            <div class="row mt-5 justify-content-center">
-              <button
-                i18n="Take the tour"
-                class="mb-4 col center text-center plausible-event-name=Tour"
-                mat-raised-button
-                color="primary"
-                (click)="startTour()"
-              >
-                Take the tour!
-              </button>
-            </div>
-          </div>
+      <div class="container mb-3">
+        <p i18n="Description of app">
+          This is a tool to help you make your own interactive 'readalong' that
+          highlights words as they are spoken. Have a look at
+          <a
+            href="https://www.eastcree.org/cree/en/lessons/read-along/northern-dialect/when-the-beaver-had-a-round-tail/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <mat-icon inline style="vertical-align: middle">launch</mat-icon>
+            this example in East Cree</a
+          >
+          to get a better idea of what these are.
+        </p>
+        <p i18n="Get started">
+          To get started making your own, click on the tour button below, and
+          follow the steps.
+        </p>
+        <div class="row center mt-0 justify-content-center">
+          <div class="col-3"></div>
+          <button
+            i18n="Take the tour"
+            class="mb-3 col-6 center text-center plausible-event-name=Tour"
+            mat-raised-button
+            color="primary"
+            (click)="startTour()"
+          >
+            Take the tour!
+          </button>
+          <div class="col-3"></div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

With the current dev preview, we are spending a lot of real estate on header material in both the editor and the studio. I want to reclaim some of it back for the app itself, by using the full screen width in the header material.

### Feedback sought? <!-- What should reviewers focus on in particular? -->

Visual impression and expression of preferences for status quo or new.

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

medium

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

n/a

### How to test? <!-- Explain how reviewers should test this PR. -->

Launch the dev preview and the PR preview, and compare the headers.
 - Studio headers
 - Editor headers on first app launch
 - Editor headers once you've loaded a readalong

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

medium

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

<!-- Add any other relevant information here -->

