### PR TITLE
build: make bundle compatible with Windows and test it in CI

### DIFF
--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -42,3 +42,9 @@ jobs:
             echo The zipped WordPress plugin packages/web-component/wordpress-plugin/read-along-web-app-loader.zip is out of date.; \
             false; \
           fi
+      - name: make sure bundling works
+        shell: bash
+        run: |
+          npx nx bundle web-component
+          git status
+          git diff --word-diff=porcelain --word-diff-regex=... --color | perl -ple 's/^(\x1b[^ -+]{0,6})? (.{81,})$/$1 . " " . substr($2, 0, 40) . " [... " . (length($2)-80) . " bytes ...] " . substr($2, -40)/ex'

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -32,8 +32,4 @@ jobs:
       - run: npx nx check-l10n studio-web
       - run: npx nx build ngx-web-component
       - run: npx nx build studio-web
-
-      # bundle only works in Git Bash on Windows, so don't exercise it here, we know it'll fail.
-      #- run: npx nx bundle web-component
-      #  shell: bash
-      #  continue-on-error: true
+      - run: npx nx bundle web-component

--- a/packages/web-component/bundle.sh
+++ b/packages/web-component/bundle.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# This script is used to bundle the web component for including in Offline HTML files
+# created by studio-web
+
+set -o errexit
+set -o verbose
+
+node b64Fonts.js
+npx webpack --config webpack.config.js
+packageVersion=$(npm view ../../node_modules/@readalongs/web-component version)
+timestamp=$(date "+%Y-%m-%d+%H-%M-%S")
+cd ../studio-web
+npm pkg set singleFileBundleVersion="${packageVersion}"
+npm pkg set singleFileBundleTimestamp="${timestamp}"

--- a/packages/web-component/package.json
+++ b/packages/web-component/package.json
@@ -15,7 +15,7 @@
     "dist/"
   ],
   "scripts": {
-    "bundle": "node b64Fonts.js && webpack --config webpack.config.js; packageVersion=$(npm view ../../node_modules/@readalongs/web-component version); timestamp=$(date \"+%Y-%m-%d+%H-%M-%S\") && cd ../studio-web && npm pkg set singleFileBundleVersion=\"${packageVersion}\" && npm pkg set singleFileBundleTimestamp=\"${timestamp}\"",
+    "bundle": "bash bundle.sh",
     "cy:run": "cypress run",
     "test:full-pipeline": "npm run serve-test-data & nx run serve & npm run wait-for-test-server && npm run test:once",
     "test:once": "cypress run",


### PR DESCRIPTION
In CI, let's this npx nx bundle web-component on both Windows and Linux, and on Linux let's display the diff in a way that we can see the bits that changed even though it's minified.

<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Make `npx nx bundle web-component` compatible with Windows, and exercise it in CI

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

the fact that the bundle command was specifically a bash command, but did not enforce being rush by bash

### Feedback sought? <!-- What should reviewers focus on in particular? -->

rubber stamping

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

low

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

yes

### How to test? <!-- Explain how reviewers should test this PR. -->

run `npx nx bundle web-component` on Windows and see it no longer fail

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

<!-- Add any other relevant information here -->
