### PR TITLE
fix: always auto-update the browserslist db on deploy

### DIFF
--- a/.github/workflows/dev-preview.yml
+++ b/.github/workflows/dev-preview.yml
@@ -1,5 +1,7 @@
 name: Deploy dev preview
-concurrency: dev-preview
+concurrency:
+  group: dev-preview
+  cancel-in-progress: true
 on:
   push:
     branches:

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -1,4 +1,7 @@
 name: Run tests
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 on:
   - push
   - workflow_call
@@ -7,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     # Stop the occasional rogue instance before the 6h GitHub limit
     timeout-minutes: 15
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -16,6 +21,22 @@ jobs:
           node-version: 20
       - name: Install everything
         run: npm install
+      - name: Always test with the latest browserslist db
+        run: |
+          npx update-browserslist-db@latest
+      - name: Commit browserslist db changes on dev branches
+        if: ${{ github.ref_type == 'branch' && ! github.ref_protected }}
+        run: |
+          if git diff --exit-code package-lock.json; then
+            echo "The browserslist db is up to date."
+          else
+            echo "The browserslist db is out of date."
+            git config --global user.email "github-actions[bot]@users.noreply.github.com"
+            git config --global user.name "github-actions[bot]"
+            git add package-lock.json
+            git commit -m "chore: update browserslist db"
+            git push
+          fi
       - name: Ng test for studio-web
         run: |
           npx nx build web-component

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,6 +1,8 @@
 # .github/workflows/preview.yml
 name: Deploy PR previews
-concurrency: preview-${{ github.ref }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 on:
   pull_request:
     types:
@@ -24,6 +26,9 @@ jobs:
         if: github.event.action != 'closed'
         run: |
           npm install
+      - name: Always test with the latest browserslist db
+        run: |
+          npx update-browserslist-db@latest
       - name: Build web-component
         if: github.event.action != 'closed'
         run: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -11088,9 +11088,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001600",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001600.tgz",
-      "integrity": "sha512-+2S9/2JFhYmYaDpZvo0lKkfvuKIglrx68MwOBqMGHhQsNkLjB5xtc/TGoEPs+MxjSyN/72qer2g97nzR641mOQ==",
+      "version": "1.0.30001667",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001667.tgz",
+      "integrity": "sha512-7LTwJjcRkzKFmtqGsibMeuXmvFDfZq/nzIjnmgCGzKKRVzjD72selLDK1oPF/Oxzmt4fNcPvTDvGqSDG4tCALw==",
       "dev": true,
       "funding": [
         {
@@ -11105,7 +11105,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/caseless": {
       "version": "0.12.0",


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

When we deploy, I often notice this message in the logs:

```
Browserslist: caniuse-lite is outdated. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
```

Instead of trying to remember to do it periodically, it seems wise to just automate it.

This automation here is to update the db and commit the changes when we are testing on a deb branch (i.e., a non-protected branch).

I also fixed some concurrency problems that I noticed while testing this PR.

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

low

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high


