### PR TITLE
fix: adjust parseReadalong to preserve the right format

### DIFF
--- a/packages/studio-web/src/app/editor/editor.component.ts
+++ b/packages/studio-web/src/app/editor/editor.component.ts
@@ -245,6 +245,17 @@ export class EditorComponent implements OnDestroy, OnInit, AfterViewInit {
   }
 
   async parseReadalong(text: string): Promise<string | undefined> {
+    // This function is designed to parse three related things:
+    //  - An Offline HTML file with the read-along HTML element with attributes href
+    //    pointing to the .readalong file, and audio pointing to the audio file,
+    //    normally both base64 encoded.
+    //  - The .readalong XML file itself
+    //  - An HTML file with the read-along HTML element and its audio attribute, but
+    //    with the contents of the .readalong file included as descendant elements
+    //    of the read-along HTML element.
+    // This is why we look for audio and href attributes, and a text child element, but
+    // don't expect to always find them.
+
     const parser = new DOMParser();
     const readalong = parser.parseFromString(text, "text/html");
     const element = readalong.querySelector("read-along");


### PR DESCRIPTION
parseFromString does a number of strange and undesirable things:
 - remove the <body> element
 - insert xmlns=
 - change ARPABET= attribute to arpabet= So we need to reverse all this, to match our .readalong DTD format!

Fixes #347

<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Re-apply #351 changes, but to the reverted main code base.

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

Fixes #347

### Feedback sought? <!-- What should reviewers focus on in particular? -->

check the code, test the fix

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

high

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

sadly no

### How to test? <!-- Explain how reviewers should test this PR. -->

Open the PR preview, go to the editor, and:
 - try to download Elan or other formats
 - change a word and its alignment and see that it's updated in any download format, i.e., confirm that didn't get broken by this PR
 - you can inspect the parsed .readalong contents by looking at the payload for the eaf call in the Network debugging pane.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

pretty high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

this and a few other patches will soon trigger patch 1.5.2

<!-- Add any other relevant information here -->
