### PR TITLE
perf: fonts are already base64 text, no need to re-base64 a second time

### DIFF
--- a/packages/studio-web/src/app/b64.service.ts
+++ b/packages/studio-web/src/app/b64.service.ts
@@ -35,9 +35,7 @@ export class B64Service {
         ),
       this.http
         .get(this.FONTS_BUNDLE_URL, { responseType: "blob" })
-        .pipe(
-          switchMap((blob: Blob) => this.fileService.readFileAsData$(blob)),
-        ),
+        .pipe(switchMap((blob: Blob) => this.fileService.readFile$(blob))),
     ]);
   }
   utf8_to_b64(str: string) {

--- a/packages/studio-web/src/app/shared/download/download.service.ts
+++ b/packages/studio-web/src/app/shared/download/download.service.ts
@@ -178,7 +178,7 @@ Please host all assets on your server, include the font and package imports defi
         <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0">
         <meta name="generator" content="@readalongs/studio-web ${environment.packageJson.singleFileBundleVersion}">
         <title>${slots.title}</title>
-        <link rel="stylesheet" href="${this.b64Service.jsAndFontsBundle$.value[1]}">
+        <style>${this.b64Service.jsAndFontsBundle$.value[1]}</style>
         <script src="${this.b64Service.jsAndFontsBundle$.value[0]}" version="${environment.packageJson.singleFileBundleVersion}" timestamp="${environment.packageJson.singleFileBundleTimestamp}"></script>
       </head>
       <body>


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Reduce the size of the Offline HTML file.

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

When we embed the fonts in the Offline HTML, we base64 encode them twice: once from the three `.woff2` files into `fonts.b64.css`, and a second time putting that into the `<link rel="stylesheet" href="...">` line in the `.html` file.

This is wasteful because the `.css` file is already plain text, having had its binary components b64 encoded already.

Instead, this PR proposes to wrap the verbatim contents of the `.css` file in a `<style>` element, which has the same effects.

The results are nice: a trivial readalong goes from 850kb down to 680kb, a saving of roughly 170kb in each RA we download as Offline HTML. 

### Feedback sought? <!-- What should reviewers focus on in particular? -->

testing to make sure this doesn't break anything!

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

low

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

no yet, no.

### How to test? <!-- Explain how reviewers should test this PR. -->

These are tests I have also done:

Create a readalong or edit an existing one, download it as single file HTML, and see it is smaller but still works correctly, even if you network cable is unplugged.

Upload it back on the currently deployed app, and see you can keep editing, and downloading it from this version or the deployed one, differs in the size of the .html file but not in functionality.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

Medium-high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no, because while the .html file is different, it is still fully backwards compatible.

<!-- Add any other relevant information here -->
