### PR TITLE
build: do not commit browserslist-db updates, it is just noise

### DIFF
--- a/.github/workflows/bundle.yml
+++ b/.github/workflows/bundle.yml
@@ -14,6 +14,7 @@ jobs:
         with:
           node-version: "20"
       - run: npm install
+      - run: npx update-browserslist-db@latest
       - run: npx nx build web-component
       - run: npx nx bundle web-component
       - name: Create Pull Request

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,16 +18,15 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
-      - name: Install
-        run: |
-          npm install
+      - run: npm install
+      - run: npx update-browserslist-db@latest
       - name: Build web-component
         run: |
           npx nx build web-component
           # create the bundles required for studio-web
           # TODO: stop updating the bundle, keep the published one.
           npx nx bundle web-component
-      - name: Test
+      - name: Specs Test
         run: |
           npx nx test:once studio-web
       - name: Build

--- a/.github/workflows/dev-preview.yml
+++ b/.github/workflows/dev-preview.yml
@@ -19,9 +19,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
-      - name: Install
-        run: |
-          npm install
+      - run: npm install
+      - run: npx update-browserslist-db@latest
       - name: Build web-component
         run: |
           npx nx build web-component

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -24,19 +24,6 @@ jobs:
       - name: Always test with the latest browserslist db
         run: |
           npx update-browserslist-db@latest
-      - name: Commit browserslist db changes on dev branches
-        if: ${{ github.ref_type == 'branch' && ! github.ref_protected }}
-        run: |
-          if git diff --exit-code package-lock.json; then
-            echo "The browserslist db is up to date."
-          else
-            echo "The browserslist db is out of date."
-            git config --global user.email "github-actions[bot]@users.noreply.github.com"
-            git config --global user.name "github-actions[bot]"
-            git add package-lock.json
-            git commit -m "chore: update browserslist db"
-            git push
-          fi
       - name: Ng test for studio-web
         run: |
           npx nx build web-component

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -26,7 +26,8 @@ jobs:
         if: github.event.action != 'closed'
         run: |
           npm install
-      - name: Always test with the latest browserslist db
+      - name: Always preview with the latest browserslist db
+        if: github.event.action != 'closed'
         run: |
           npx update-browserslist-db@latest
       - name: Build web-component

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           scope: "@readalongs"
       - run: npm install
+      - run: npx update-browserslist-db@latest
       - name: Build and bundle
         run: |
           npx nx build web-component

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -13,6 +13,7 @@ jobs:
         with:
           node-version: 20
       - run: npm install --verbose
+      - run: npx update-browserslist-db@latest
       - name: Ng test for studio-web
         run: |
           npx nx build web-component

--- a/packages/studio-web/project.json
+++ b/packages/studio-web/project.json
@@ -80,8 +80,12 @@
       },
       "defaultConfiguration": "production"
     },
+    "update-browserslist": {
+      "command": "npx update-browserslist-db@latest"
+    },
     "serve": {
       "executor": "@angular-builders/custom-webpack:dev-server",
+      "dependsOn": ["update-browserslist"],
       "configurations": {
         "production-en": {
           "buildTarget": "studio-web:build:production,en"


### PR DESCRIPTION
### PR Goal? <!-- Explain the main objective of this PR. -->

The strategy I implemented in #348 to always update the browserslist-db on install *and commit the results* creates a lot of noise: a lot of similar commits, and we still want to update this db in deploy anyway, so it's not the right strategy.

This commit removes the code that commits the changes, and instead updates the db in every workflow that tests or deploys Studio-Web.

Furthermore, Del ~~is going to add~~ has added a build-time dependency that will do this update automatically when you build or serve locally, so we do the same everywhere, automatically, and reasonably quietly.

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

will reduce the number of silly nearly meaningless commits to `package-lock.json`.

### Feedback sought? <!-- What should reviewers focus on in particular? -->

Once Del implements the auto update on build, that will create local changes. Are we OK with just grabbing those with other commits we're doing locally? Or do we want to avoid committing those changes (that would be a real nuisance)?

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

low

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

n/a

### How to test? <!-- Explain how reviewers should test this PR. -->

It's just CI, so look at CI results for this PR.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

medium

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

<!-- Add any other relevant information here -->
