### PR TITLE
fix(ci): wait on web-component needs sleep, URL is not reliable

### DIFF
--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -48,7 +48,7 @@ jobs:
           start: |
             npx nx serve web-component
             npx nx serve-test-data web-component
-          wait-on: "http://localhost:3333/build/web-component.esm.js"
+          wait-on: sleep 15 # there is no reliable URL to wait for...
           command: npx nx test:once web-component
       - name: Check that i18n and l10n are up to date
         run: |

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -25,7 +25,7 @@ jobs:
           start: |
             npx nx serve web-component
             npx nx serve-test-data web-component
-          wait-on: "http://localhost:3333/build/web-component.esm.js"
+          wait-on: sleep 15 # there is no reliable URL to wait for...
           command: npx nx test:once web-component
 
       - run: npx nx extract-i18n studio-web

--- a/package-lock.json
+++ b/package-lock.json
@@ -11088,9 +11088,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001679",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001679.tgz",
-      "integrity": "sha512-j2YqID/YwpLnKzCmBOS4tlZdWprXm3ZmQLBH9ZBXFOhoxLA46fwyBvx6toCBWBmnuwUY/qB3kEU6gFx8qgCroA==",
+      "version": "1.0.30001680",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001680.tgz",
+      "integrity": "sha512-rPQy70G6AGUMnbwS1z6Xg+RkHYPAi18ihs47GH0jcxIG7wArmPgY3XbS2sRdBbxJljp3thdT8BIqv9ccCypiPA==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Stabilize the flaky web-component test in CI

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

The Web-Component cypress test fails every now and again, randomly, and it turns out it's because server hasn't finished starting yet when Cypress starts to do the tests.

The problem is that `wait-on: "http://localhost:3333/build/web-component.esm.js"` is not sufficient: that tiny page is available quickly, but the other .js file it points to are not, but their name contains a hash so we can't wait on them.

Doing a `sleep 15` is kinda ugly, but it's the best I could find. The runs I checked took 9 seconds.

### Feedback sought? <!-- What should reviewers focus on in particular? -->

rubber stamping, really, unless you have a better solution.

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

medium

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

n/a

### How to test? <!-- Explain how reviewers should test this PR. -->

Just see that CI is more reliable, but it was a sporadic problem, so it's only over time we'll see the difference.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

pretty high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

<!-- Add any other relevant information here -->
