### PR TITLE
Restore smaller upload file size limits

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "name": "root",
+      "license": "(MIT AND BSD-3-Clause)",
       "workspaces": [
         "packages/*"
       ],
@@ -11150,9 +11151,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001687",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001687.tgz",
-      "integrity": "sha512-0S/FDhf4ZiqrTUiQ39dKeUjYRjkv7lOZU1Dgif2rIqrTzX/1wV2hfKu9TOm1IHkdSijfLswxTFzl/cvir+SLSQ==",
+      "version": "1.0.30001695",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001695.tgz",
+      "integrity": "sha512-vHyLade6wTgI2u1ec3WQBxv+2BrTERV28UXQu9LO6lZ9pYeMk34vjXFLOxo1A4UBA8XTL4njRQZdno/yYaSmWw==",
       "dev": true,
       "funding": [
         {
@@ -27717,6 +27718,7 @@
     "packages/ngx-web-component": {
       "name": "@readalongs/ngx-web-component",
       "version": "1.5.2",
+      "license": "MIT",
       "peerDependencies": {
         "@angular/common": "^17",
         "@angular/core": "^17",
@@ -27726,6 +27728,7 @@
     "packages/studio-web": {
       "name": "readalong-studio",
       "version": "0.0.0",
+      "license": "(MIT AND BSD-3-Clause)",
       "dependencies": {
         "readalong-studio": "file:"
       }

--- a/packages/studio-web/src/app/upload/upload.component.ts
+++ b/packages/studio-web/src/app/upload/upload.component.ts
@@ -59,8 +59,10 @@ export class UploadComponent implements OnDestroy, OnInit {
   contactLink = environment.packageJson.contact;
   progressMode: ProgressBarMode = "indeterminate";
   progressValue = 0;
-  maxTxtSizeKB = 250; // Max 250 KB plain text file size
-  maxRasSizeKB = 250; // Max 250 KB .readalong XML text size
+  // Max plain text file size: 40KB is OK but takes around 15-20s on Heroku
+  maxTxtSizeKB = 40;
+  // Max .readalong XML text size: text * 5 is a rough heuristic; the XML is much bloated from the text.
+  maxRasSizeKB = 200;
   @ViewChild("textInputElement") textInputElement: ElementRef;
   @Output() stepChange = new EventEmitter<any[]>();
 

--- a/packages/studio-web/src/app/upload/upload.component.ts
+++ b/packages/studio-web/src/app/upload/upload.component.ts
@@ -334,10 +334,25 @@ Please check it to make sure all words are spelled out completely, e.g. write "4
     }
     if (this.studioService.inputMethod.text === "edit") {
       if (this.studioService.$textInput.value) {
-        let inputText = new Blob([this.studioService.$textInput.value], {
-          type: "text/plain",
-        });
-        this.studioService.textControl$.setValue(inputText);
+        const inputLength = this.studioService.$textInput.value.length;
+        if (inputLength > this.maxTxtSizeKB * 1024) {
+          this.toastr.error(
+            $localize`Text too large. Max size: ` +
+              this.maxTxtSizeKB +
+              $localize` KB.` +
+              $localize` Current size: ` +
+              Math.ceil(inputLength / 1024) +
+              $localize` KB.`,
+            $localize`Sorry!`,
+            { timeOut: 15000 },
+          );
+          return;
+        } else {
+          let inputText = new Blob([this.studioService.$textInput.value], {
+            type: "text/plain",
+          });
+          this.studioService.textControl$.setValue(inputText);
+        }
       } else {
         this.toastr.error(
           $localize`Please enter text to align.`,
@@ -527,8 +542,9 @@ Please check it to make sure all words are spelled out completely, e.g. write "4
           : this.maxTxtSizeKB;
       if (file.size > maxSizeKB * 1024) {
         this.toastr.error(
-          $localize`File too large. Max size: ` + maxSizeKB + $localize` KB`,
+          $localize`File too large. Max size: ` + maxSizeKB + $localize` KB.`,
           $localize`Sorry!`,
+          { timeOut: 15000 },
         );
         this.textInputElement.nativeElement.value = "";
       } else {

--- a/packages/studio-web/src/i18n/messages.es.json
+++ b/packages/studio-web/src/i18n/messages.es.json
@@ -154,6 +154,9 @@
     "1983793909601149790": "Por favor inténtelo de nuevo o seleccione un fichero pre-grabado.",
     "3896053555277429649": "Por favor seleccione un idioma o la opción predeterminada",
     "8052409322099101104": "Ningún idioma seleccionado",
+    "2970892766726423212": "El texto es demasiado grande. Tamaño máximo: ",
+    "1227277325872790936": " KB.",
+    "4346774921429520933": " Tamaño actual: ",
     "3533349926767927338": "Por favor entre el texto que quiere alinear.",
     "7881212750036563398": "Sin texto",
     "3578398528078428417": "Por favor seleccione un fichero de texto.",
@@ -170,7 +173,6 @@
     "1326685349515945581": " procesado pero no cargado. Su audio se mantendrá en su computadora.",
     "6899344040225872362": "¡Genial!",
     "7895338145504956239": "Fichero demasiado grande. Tamaño máximo: ",
-    "5997429059663319535": " KB",
     "2722548994886578004": " procesado. El texto se cargará mediante una conexión encriptada cuando pase al próximo paso."
   }
 }

--- a/packages/studio-web/src/i18n/messages.fr.json
+++ b/packages/studio-web/src/i18n/messages.fr.json
@@ -154,6 +154,9 @@
     "1983793909601149790": "Prière de réessayer ou de choisir un fichier pré-enregistré.",
     "3896053555277429649": "Prière de choisir une langue ou l'option par défaut",
     "8052409322099101104": "Pas de langue choisie",
+    "2970892766726423212": "Texte trop long. Limite: ",
+    "1227277325872790936": " Ko.",
+    "4346774921429520933": " Taille actuelle: ",
     "3533349926767927338": "Prière de saisir le texte à aligner.",
     "7881212750036563398": "Pas de texte",
     "3578398528078428417": "Prière de choisir un fichier texte.",
@@ -170,7 +173,6 @@
     "1326685349515945581": " lu, mais pas téléversé. Votre audio restera sur votre ordinateur.",
     "6899344040225872362": "Bravo!",
     "7895338145504956239": "Fichier trop lourd. Poids maximal: ",
-    "5997429059663319535": " Ko",
     "2722548994886578004": " lu. Il sera téléversé à l'aide d'une connexion chiffrée quand vous passerez à la prochaine étape."
   }
 }

--- a/packages/studio-web/src/i18n/messages.json
+++ b/packages/studio-web/src/i18n/messages.json
@@ -154,6 +154,9 @@
     "1983793909601149790": "Please try again, or select a pre-recorded file.",
     "3896053555277429649": "Please select a language or choose the default option",
     "8052409322099101104": "No language selected",
+    "2970892766726423212": "Text too large. Max size: ",
+    "1227277325872790936": " KB.",
+    "4346774921429520933": " Current size: ",
     "3533349926767927338": "Please enter text to align.",
     "7881212750036563398": "No text",
     "3578398528078428417": "Please select a text file.",
@@ -170,7 +173,6 @@
     "1326685349515945581": " processed, but not uploaded. Your audio will stay on your computer.",
     "6899344040225872362": "Great!",
     "7895338145504956239": "File too large. Max size: ",
-    "5997429059663319535": " KB",
     "2722548994886578004": " processed. It will be uploaded through an encrypted connection when you go to the next step."
   }
 }


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

While our old limits of 30KB/60KB were too low to allow realistic Studio-Web use, 250KB is causing crashes. I can crash the server with a 50kb file, even. So restore the max size for text to 40KB, but since the XML is quite bloated, allow 200KB for .readalong inputs.

While I'm here, I also added the same size limit to the text box, so that cut-and-pasting can't be used as a work around for the limit and bring the crashes back.

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

Heroku crash warnings we receive once in a while. Hopefully. 🤞 

### Feedback sought? <!-- What should reviewers focus on in particular? -->

Make sure the code is OK.

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

high

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

Normal use is already covered by CI.

Exceeding the limits is not tested, no.

### How to test? <!-- Explain how reviewers should test this PR. -->

Spin up locally, or use the PR preview, and submit text file text file > 40kb, or .readalong file > 200kb, and see an error toast.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

<!-- Add any other relevant information here -->
