### PR TITLE
fix: improve the various text-too-big messages

### DIFF
--- a/packages/studio-web/src/app/upload/upload.component.ts
+++ b/packages/studio-web/src/app/upload/upload.component.ts
@@ -337,7 +337,8 @@ Please check it to make sure all words are spelled out completely, e.g. write "4
         const inputLength = this.studioService.$textInput.value.length;
         if (inputLength > this.maxTxtSizeKB * 1024) {
           this.toastr.error(
-            $localize`Text too large. Max size: ` +
+            $localize`Text too large. ` +
+              $localize`Max size: ` +
               this.maxTxtSizeKB +
               $localize` KB.` +
               $localize` Current size: ` +
@@ -536,13 +537,21 @@ Please check it to make sure all words are spelled out completely, e.g. write "4
         { timeOut: 10000 },
       );
     } else if (type === "text") {
-      let maxSizeKB =
-        file.name.split(".").pop() === "readalong"
-          ? this.maxRasSizeKB
-          : this.maxTxtSizeKB;
+      let maxSizeKB;
+      let fileTooBigMessage;
+      if (file.name.split(".").pop() === "readalong") {
+        maxSizeKB = this.maxRasSizeKB;
+        fileTooBigMessage = $localize`.readalong file too large. `;
+      } else {
+        maxSizeKB = this.maxTxtSizeKB;
+        fileTooBigMessage = $localize`Text file too large. `;
+      }
       if (file.size > maxSizeKB * 1024) {
         this.toastr.error(
-          $localize`File too large. Max size: ` + maxSizeKB + $localize` KB.`,
+          fileTooBigMessage +
+            $localize`Max size: ` +
+            maxSizeKB +
+            $localize` KB.`,
           $localize`Sorry!`,
           { timeOut: 15000 },
         );

--- a/packages/studio-web/src/app/upload/upload.component.ts
+++ b/packages/studio-web/src/app/upload/upload.component.ts
@@ -333,6 +333,7 @@ Please check it to make sure all words are spelled out completely, e.g. write "4
       return;
     }
     if (this.studioService.inputMethod.text === "edit") {
+      this.studioService.textControl$.setValue(null);
       if (this.studioService.$textInput.value) {
         const inputLength = this.studioService.$textInput.value.length;
         if (inputLength > this.maxTxtSizeKB * 1024) {
@@ -393,9 +394,11 @@ Please check it to make sure all words are spelled out completely, e.g. write "4
           this.studioService.textControl$.value.name
             .toLowerCase()
             .endsWith(".readalong"))
-      )
+      ) {
         input_type = "application/readalong+xml";
-      else input_type = "text/plain";
+      } else {
+        input_type = "text/plain";
+      }
       // Create request (text is possibly read from a file later...)
       let body: ReadAlongRequest = {
         text_languages: [

--- a/packages/studio-web/src/i18n/messages.es.json
+++ b/packages/studio-web/src/i18n/messages.es.json
@@ -154,7 +154,8 @@
     "1983793909601149790": "Por favor inténtelo de nuevo o seleccione un fichero pre-grabado.",
     "3896053555277429649": "Por favor seleccione un idioma o la opción predeterminada",
     "8052409322099101104": "Ningún idioma seleccionado",
-    "2970892766726423212": "El texto es demasiado grande. Tamaño máximo: ",
+    "6423301374041491740": "El texto es demasiado grande. ",
+    "8484763613240787586": "Tamaño máximo: ",
     "1227277325872790936": " KB.",
     "4346774921429520933": " Tamaño actual: ",
     "3533349926767927338": "Por favor entre el texto que quiere alinear.",
@@ -172,7 +173,8 @@
     "7719309746449095739": "Fichero ",
     "1326685349515945581": " procesado pero no cargado. Su audio se mantendrá en su computadora.",
     "6899344040225872362": "¡Genial!",
-    "7895338145504956239": "Fichero demasiado grande. Tamaño máximo: ",
+    "1957629163103268830": "Fichero .readalong demasiado grande. ",
+    "6695070918205441013": "Fichero de texto demasiado grande. ",
     "2722548994886578004": " procesado. El texto se cargará mediante una conexión encriptada cuando pase al próximo paso."
   }
 }

--- a/packages/studio-web/src/i18n/messages.fr.json
+++ b/packages/studio-web/src/i18n/messages.fr.json
@@ -154,7 +154,8 @@
     "1983793909601149790": "Prière de réessayer ou de choisir un fichier pré-enregistré.",
     "3896053555277429649": "Prière de choisir une langue ou l'option par défaut",
     "8052409322099101104": "Pas de langue choisie",
-    "2970892766726423212": "Texte trop long. Limite: ",
+    "6423301374041491740": "Texte trop long. ",
+    "8484763613240787586": "Limite: ",
     "1227277325872790936": " Ko.",
     "4346774921429520933": " Taille actuelle: ",
     "3533349926767927338": "Prière de saisir le texte à aligner.",
@@ -172,7 +173,8 @@
     "7719309746449095739": "Fichier ",
     "1326685349515945581": " lu, mais pas téléversé. Votre audio restera sur votre ordinateur.",
     "6899344040225872362": "Bravo!",
-    "7895338145504956239": "Fichier trop lourd. Poids maximal: ",
+    "1957629163103268830": "Fichier .readalong trop gros. ",
+    "6695070918205441013": "Fichier texte trop gros. ",
     "2722548994886578004": " lu. Il sera téléversé à l'aide d'une connexion chiffrée quand vous passerez à la prochaine étape."
   }
 }

--- a/packages/studio-web/src/i18n/messages.json
+++ b/packages/studio-web/src/i18n/messages.json
@@ -154,7 +154,8 @@
     "1983793909601149790": "Please try again, or select a pre-recorded file.",
     "3896053555277429649": "Please select a language or choose the default option",
     "8052409322099101104": "No language selected",
-    "2970892766726423212": "Text too large. Max size: ",
+    "6423301374041491740": "Text too large. ",
+    "8484763613240787586": "Max size: ",
     "1227277325872790936": " KB.",
     "4346774921429520933": " Current size: ",
     "3533349926767927338": "Please enter text to align.",
@@ -172,7 +173,8 @@
     "7719309746449095739": "File ",
     "1326685349515945581": " processed, but not uploaded. Your audio will stay on your computer.",
     "6899344040225872362": "Great!",
-    "7895338145504956239": "File too large. Max size: ",
+    "1957629163103268830": ".readalong file too large. ",
+    "6695070918205441013": "Text file too large. ",
     "2722548994886578004": " processed. It will be uploaded through an encrypted connection when you go to the next step."
   }
 }


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Right now, it could be confusing that you are told the file size limit is 40KB, without specifying that it's specifically for text files, but it's different for .readalong files. The message is now tweaked to make it clearer that the limit shown (40KB or 200KB) is for the given file type, Text file or .readalong file.

### Feedback sought? <!-- What should reviewers focus on in particular? -->

general validation and testing.

This is not exercised in CI, so ideally manual testing, even though I'm doing my own as well.

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

high, I'd like to deploy this quickly to avoid possible user confusion.

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

max size cases are not in CI yet, but it would be a good idea to add these to e2e testing. @deltork ?

### How to test? <!-- Explain how reviewers should test this PR. -->

For each language:
 - select a text file that's >40kb and get an error toast
 - select a .readalong file that's > 200kb and get an error toast
 - paste more than 40kb of text into the text box and click "Go to the next step!" and get an error toast

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

medium-high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

<!-- Add any other relevant information here -->
