### PR TITLE
Dev.ej/document how to open

### DIFF
--- a/packages/studio-web/src/app/shared/download/download.service.ts
+++ b/packages/studio-web/src/app/shared/download/download.service.ts
@@ -187,24 +187,51 @@ Please host all assets on your server, include the font and package imports defi
     if (this.b64Service.jsAndFontsBundle$.value !== null) {
       let blob = new Blob(
         [
-          `<!DOCTYPE html>
-      <html lang="en">
-      <head>
-        <meta charset="utf-8">
-        <meta name="application-name" content="read along">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0">
-        <meta name="generator" content="@readalongs/studio-web ${environment.packageJson.singleFileBundleVersion}">
-        <title>${slots.title}</title>
-        <style>${this.b64Service.jsAndFontsBundle$.value[1]}</style>
-        <script src="${this.b64Service.jsAndFontsBundle$.value[0]}" version="${environment.packageJson.singleFileBundleVersion}" timestamp="${environment.packageJson.singleFileBundleTimestamp}"></script>
-      </head>
-      <body>
-          <read-along version="${environment.packageJson.singleFileBundleVersion}"  href="data:application/readalong+xml;base64,${rasB64}" audio="${b64Audio}" image-assets-folder="">
-          <span slot="read-along-header">${slots.title}</span>
-          <span slot="read-along-subheader">${slots.subtitle}</span>
-          </read-along>
-      </body>
-      </html>`,
+          `
+            <!DOCTYPE html>
+
+            <!--
+
+                                Instructions for Opening this File
+
+            This is a read-along file that can be opened in a web browser without
+            requiring Internet access.
+
+            If you see this text, you probably downloaded a ReadAlong HTML file from a
+            cloud storage service, and it's showing you the raw contents instead of
+            displaying your readalong.
+
+            To view the file:
+
+            1. Download the file to your computer -- there should be a download button
+               visible or hidden in the three dot menu in your cloud storage service.
+
+            2. Once downloaded, open the file in a web browser. You can do this by
+               double-clicking it in your file explorer or in your browser's downloaded
+               files list.
+
+            -->
+
+            <html lang="en">
+              <head>
+                <meta charset="utf-8">
+                <meta name="application-name" content="read along">
+                <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0">
+                <meta name="generator" content="@readalongs/studio-web ${environment.packageJson.singleFileBundleVersion}">
+                <title>${slots.title}</title>
+                <style>${this.b64Service.jsAndFontsBundle$.value[1]}</style>
+                <script src="${this.b64Service.jsAndFontsBundle$.value[0]}" version="${environment.packageJson.singleFileBundleVersion}" timestamp="${environment.packageJson.singleFileBundleTimestamp}"></script>
+              </head>
+              <body>
+                <read-along version="${environment.packageJson.singleFileBundleVersion}"  href="data:application/readalong+xml;base64,${rasB64}" audio="${b64Audio}" image-assets-folder="">
+                <span slot="read-along-header">${slots.title}</span>
+                <span slot="read-along-subheader">${slots.subtitle}</span>
+                </read-along>
+              </body>
+            </html>
+          `
+            .replace(/\n            /g, "\n")
+            .trim(),
         ],
         { type: "text/html;charset=utf-8" },
       );
@@ -313,28 +340,30 @@ Please host all assets on your server, include the font and package imports defi
       const sampleHtml = `
         <!DOCTYPE html>
         <html lang="en">
-            <head>
-                <meta charset="UTF-8">
-                <title>${slots.title}</title>
-                <meta name="application-name" content="read along">
-                <meta name="generator" content="@readalongs/studio-web ${environment.packageJson.singleFileBundleVersion}">
-                <meta name="viewport" content="width=device-width, initial-scale=1" />
-                <!-- Import fonts. Material Icons are needed by the web component -->
-                <link href="https://fonts.googleapis.com/css?family=Lato%7CMaterial+Icons%7CMaterial+Icons+Outlined" rel="stylesheet">
-            </head>
+          <head>
+            <meta charset="UTF-8">
+            <title>${slots.title}</title>
+            <meta name="application-name" content="read along">
+            <meta name="generator" content="@readalongs/studio-web ${environment.packageJson.singleFileBundleVersion}">
+            <meta name="viewport" content="width=device-width, initial-scale=1" />
+            <!-- Import fonts. Material Icons are needed by the web component -->
+            <link href="https://fonts.googleapis.com/css?family=Lato%7CMaterial+Icons%7CMaterial+Icons+Outlined" rel="stylesheet">
+          </head>
 
-            <body>
-                <!-- Here is how you declare the Web Component. Supported languages: en, fr -->
-                <read-along href="assets/${basename}.readalong" audio="assets/${basename}.${audioExtension}" theme="light" language="en" image-assets-folder="assets/">
-                    <span slot='read-along-header'>${slots.title}</span>
-                    <span slot='read-along-subheader'>${slots.subtitle}</span>
-                </read-along>
-            </body>
+          <body>
+            <!-- Here is how you declare the Web Component. Supported languages: en, fr -->
+            <read-along href="assets/${basename}.readalong" audio="assets/${basename}.${audioExtension}" theme="light" language="en" image-assets-folder="assets/">
+              <span slot='read-along-header'>${slots.title}</span>
+              <span slot='read-along-subheader'>${slots.subtitle}</span>
+            </read-along>
+          </body>
 
-            <!-- The last step needed is to import the package -->
-            <script type="module" src='https://unpkg.com/@readalongs/web-component@^${environment.packageJson.singleFileBundleVersion}/dist/web-component/web-component.esm.js'></script>
+          <!-- The last step needed is to import the package -->
+          <script type="module" src='https://unpkg.com/@readalongs/web-component@^${environment.packageJson.singleFileBundleVersion}/dist/web-component/web-component.esm.js'></script>
         </html>
-        `;
+      `
+        .replace(/\n        /g, "\n")
+        .trim();
       const indexHtmlFile = new Blob([sampleHtml], { type: "text/html" });
       innerFolder?.file("index.html", indexHtmlFile);
       //snippet for WP deployment


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

When a single-file HTML is opened from Google Drive, you see the raw HTML instead of the file.

We had discussed two solutions, which we both need:
 1- fix how files get opened in Google Drive
 2- have the raw HTML show instructions.

This PR implements 2.

### Feedback sought? <!-- What should reviewers focus on in particular? -->

validation of my help text

### Note

When reviewing, the diff looks big because I also fixed the indentation and used .trim and .replace to de-indent the HTML. Looking at the diff with `git diff -w` is much nicer, highlighting just the new help text.

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

before ICLDC

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

was already covered, I'm just changing the specific template strings

### How to test? <!-- Explain how reviewers should test this PR. -->

Create an RAS and download the Offline HTML. Upload it to Google Drive, double click on it, and see this:

![image](https://github.com/user-attachments/assets/4c981d9f-02f7-4f01-aa18-10138f2f66b7)


### Confidence? <!-- How confident are you that these changes are ready to merge? -->

High for the implementation, medium for the specific instructions I wrote.

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

maybe a patch-level bump

<!-- Add any other relevant information here -->
