### PR TITLE
Dev.ej/streamline bundle

### DIFF
--- a/packages/studio-web/src/app/b64.service.ts
+++ b/packages/studio-web/src/app/b64.service.ts
@@ -23,7 +23,10 @@ export class B64Service {
     private fileService: FileService,
   ) {
     this.getBundle$().subscribe((bundle) => {
-      this.jsAndFontsBundle$.next(bundle);
+      this.jsAndFontsBundle$.next([
+        this.indent(bundle[0], 6), //apply the indentation to the js bundle
+        this.indent(bundle[1], 6),
+      ]);
     });
   }
   getBundle$(): Observable<[string, string]> {
@@ -31,6 +34,7 @@ export class B64Service {
       this.http
         .get(this.JS_BUNDLE_URL, { responseType: "blob" })
         .pipe(switchMap((blob: Blob) => this.fileService.readFile$(blob))),
+
       this.http
         .get(this.FONTS_BUNDLE_URL, { responseType: "blob" })
         .pipe(switchMap((blob: Blob) => this.fileService.readFile$(blob))),
@@ -70,6 +74,7 @@ export class B64Service {
 
   indent(str: string, level: number) {
     const indent = " ".repeat(level);
+
     return str
       .split("\n")
       .map((line) => (line.trim() ? indent + line : line))

--- a/packages/studio-web/src/app/b64.service.ts
+++ b/packages/studio-web/src/app/b64.service.ts
@@ -30,9 +30,7 @@ export class B64Service {
     return forkJoin([
       this.http
         .get(this.JS_BUNDLE_URL, { responseType: "blob" })
-        .pipe(
-          switchMap((blob: Blob) => this.fileService.readFileAsData$(blob)),
-        ),
+        .pipe(switchMap((blob: Blob) => this.fileService.readFile$(blob))),
       this.http
         .get(this.FONTS_BUNDLE_URL, { responseType: "blob" })
         .pipe(switchMap((blob: Blob) => this.fileService.readFile$(blob))),

--- a/packages/studio-web/src/app/b64.service.ts
+++ b/packages/studio-web/src/app/b64.service.ts
@@ -67,4 +67,12 @@ export class B64Service {
       reader.readAsDataURL(blob);
     });
   }
+
+  indent(str: string, level: number) {
+    const indent = " ".repeat(level);
+    return str
+      .split("\n")
+      .map((line) => (line.trim() ? indent + line : line))
+      .join("\n");
+  }
 }

--- a/packages/studio-web/src/app/shared/download/download.service.ts
+++ b/packages/studio-web/src/app/shared/download/download.service.ts
@@ -220,10 +220,10 @@ Please host all assets on your server, include the font and package imports defi
                 <meta name="generator" content="@readalongs/studio-web ${environment.packageJson.singleFileBundleVersion}">
                 <title>${slots.title}</title>
                 <style>
-            ${this.b64Service.indent(this.b64Service.jsAndFontsBundle$.value[1], 6)}
+            ${this.b64Service.jsAndFontsBundle$.value[1]}
                 </style>
                 <script name="@readalongs/web-component" version="${environment.packageJson.singleFileBundleVersion}" timestamp="${environment.packageJson.singleFileBundleTimestamp}">
-            ${this.b64Service.indent(this.b64Service.jsAndFontsBundle$.value[0], 6)}
+            ${this.b64Service.jsAndFontsBundle$.value[0]}
                 </script>
               </head>
               <body>

--- a/packages/studio-web/src/app/shared/download/download.service.ts
+++ b/packages/studio-web/src/app/shared/download/download.service.ts
@@ -219,13 +219,22 @@ Please host all assets on your server, include the font and package imports defi
                 <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0">
                 <meta name="generator" content="@readalongs/studio-web ${environment.packageJson.singleFileBundleVersion}">
                 <title>${slots.title}</title>
-                <style>${this.b64Service.jsAndFontsBundle$.value[1]}</style>
-                <script src="${this.b64Service.jsAndFontsBundle$.value[0]}" version="${environment.packageJson.singleFileBundleVersion}" timestamp="${environment.packageJson.singleFileBundleTimestamp}"></script>
+                <style>
+            ${this.b64Service.indent(this.b64Service.jsAndFontsBundle$.value[1], 6)}
+                </style>
+                <script name="@readalongs/web-component" version="${environment.packageJson.singleFileBundleVersion}" timestamp="${environment.packageJson.singleFileBundleTimestamp}">
+            ${this.b64Service.indent(this.b64Service.jsAndFontsBundle$.value[0], 6)}
+                </script>
               </head>
               <body>
-                <read-along version="${environment.packageJson.singleFileBundleVersion}"  href="data:application/readalong+xml;base64,${rasB64}" audio="${b64Audio}" image-assets-folder="">
-                <span slot="read-along-header">${slots.title}</span>
-                <span slot="read-along-subheader">${slots.subtitle}</span>
+                <read-along
+                  version="${environment.packageJson.singleFileBundleVersion}"
+                  href="data:application/readalong+xml;base64,${rasB64}"
+                  audio="${b64Audio}"
+                  image-assets-folder=""
+                >
+                  <span slot="read-along-header">${slots.title}</span>
+                  <span slot="read-along-subheader">${slots.subtitle}</span>
                 </read-along>
               </body>
             </html>
@@ -351,8 +360,14 @@ Please host all assets on your server, include the font and package imports defi
           </head>
 
           <body>
-            <!-- Here is how you declare the Web Component. Supported languages: en, fr -->
-            <read-along href="assets/${basename}.readalong" audio="assets/${basename}.${audioExtension}" theme="light" language="en" image-assets-folder="assets/">
+            <!-- Here is how you declare the Web Component. Supported languages: eng, fra, spa -->
+            <read-along
+              href="assets/${basename}.readalong"
+              audio="assets/${basename}.${audioExtension}"
+              theme="light"
+              language="eng"
+              image-assets-folder="assets/"
+            >
               <span slot='read-along-header'>${slots.title}</span>
               <span slot='read-along-subheader'>${slots.subtitle}</span>
             </read-along>


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

This work was triggered by noticing that a .html file someone just sent us was hard to analyse by hand, in terms of what versions of things were used. So I decided to add newlines so that the text part of stuff is still visible when you disable line-wrapping, and add more versioning information to the generated files.

Also, the web-component script does not need to be base64-encoded, that's just bloat: include it directly as is instead.

And in the script tag, add a `name="@readalongs/web-component"` attribute to better document where the script came from.

See also https://github.com/ReadAlongs/Studio/pull/265 for related changes to the CLI.

### Feedback sought? <!-- What should reviewers focus on in particular? -->

General validation.

Question: is there a way to apply my indent in the pipe and switchmap business in b64.service.ts, instead of at download time, so that it could happen in the background earlier?

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

normal

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->



### How to test? <!-- Explain how reviewers should test this PR. -->

Generate a readalong, download the offline HTML, open it and choose view source to inspect it.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

good

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

<!-- Add any other relevant information here -->
