### PR TITLE
fix: audio file re-selection

### DIFF
--- a/packages/studio-web/src/app/upload/upload.component.html
+++ b/packages/studio-web/src/app/upload/upload.component.html
@@ -151,6 +151,7 @@ Page two."
             >Use pre-recorded audio from an MP3 or WAV file.</label
           >
           <input
+            #audioFileUpload
             (change)="onFileSelected('audio', $event)"
             class="form-control"
             name="audio"

--- a/packages/studio-web/src/app/upload/upload.component.ts
+++ b/packages/studio-web/src/app/upload/upload.component.ts
@@ -65,6 +65,7 @@ export class UploadComponent implements OnDestroy, OnInit {
   maxRasSizeKB = 200;
   currentToast: number;
   @ViewChild("textInputElement") textInputElement: ElementRef;
+  @ViewChild("audioFileUpload") audioFileUpload: ElementRef<HTMLFormElement>;
   @Output() stepChange = new EventEmitter<any[]>();
 
   unsubscribe$ = new Subject<void>();
@@ -277,6 +278,7 @@ Please check it to make sure all words are spelled out completely, e.g. write "4
   }
 
   deleteRecording() {
+    this.audioFileUpload.nativeElement.value = "";
     this.studioService.audioControl$.setValue(null);
   }
 


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Fixes the issue when a user selects an audio file then deletes it; they can now reselect the same audio file.


### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

Fixes #365 

### Feedback sought? <!-- What should reviewers focus on in particular? -->



### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->



### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->


### How to test? <!-- Explain how reviewers should test this PR. -->



### Confidence? <!-- How confident are you that these changes are ready to merge? -->

High.


### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->



<!-- Add any other relevant information here -->
