### PR TITLE
fix: text file broken in bundle

### DIFF
--- a/packages/studio-web/tests/editor/download-web-bundle.spec.ts
+++ b/packages/studio-web/tests/editor/download-web-bundle.spec.ts
@@ -1,0 +1,77 @@
+import { test, expect } from "@playwright/test";
+import { testAssetsPath, disablePlausible } from "../test-commands";
+import fs from "fs";
+import JSZip from "jszip";
+
+test("should Download web bundle (zip file format) from the Editor", async ({
+  page,
+  isMobile,
+}) => {
+  await page.goto("/", { waitUntil: "load" });
+
+  await disablePlausible(page);
+  if (isMobile) {
+    await page.getByTestId("menu-toggle").click();
+  }
+  await page.getByRole("button", { name: /Editor/ }).click();
+
+  await expect(
+    page.locator("#updateRAS"),
+    "Choose file is visible",
+  ).toBeVisible();
+  let fileChooserPromise = page.waitForEvent("filechooser");
+  await page.locator("#updateRAS").click();
+  let fileChooser = await fileChooserPromise;
+  await fileChooser.setFiles(testAssetsPath + "sentence-paragr.html");
+
+  // Test download web-bundle functionality
+  await page.getByTestId("download-formats").click();
+  await page.getByRole("option", { name: "Web Bundle" }).click();
+  const download1Promise = page.waitForEvent("download");
+  await page.getByTestId("download-ras").click();
+  const download1 = await download1Promise;
+  expect(
+    download1.suggestedFilename(),
+    "should have the expected filename",
+  ).toMatch(/sentence\-paragr\-[0-9]*\.zip/);
+  const zipPath = await download1.path();
+  const zipBin = await fs.readFileSync(zipPath);
+  const zip = await JSZip.loadAsync(zipBin);
+  verifyWebBundle(zip);
+});
+
+// verify web-bundle contents used by tests in editor.
+function verifyWebBundle(zip: JSZip) {
+  expect(
+    zip.folder(/Offline-HTML/),
+    "should have Offline-HTML folder",
+  ).toHaveLength(1);
+  expect(
+    zip.file(/Offline-HTML\/sentence\-paragr\-[0-9]*\.html/),
+    "should have Offline-HTML file",
+  ).toHaveLength(1);
+  expect(zip.folder(/www/).length, "should have www folder").toBeGreaterThan(1);
+  expect(zip.folder(/www\/assets/), "should have assets folder").toHaveLength(
+    1,
+  );
+  expect(
+    zip.file(/www\/assets\/sentence\-paragr\-[0-9]*\.readalong/),
+    "should have readalong file",
+  ).toHaveLength(1);
+  expect(
+    zip.file(/www\/assets\/sentence\-paragr\-[0-9]*\.wav/),
+    "should have wav file",
+  ).toHaveLength(1);
+  expect(
+    zip.file(/www\/assets\/image-sentence\-paragr\-[0-9\-]*\.png/),
+    "should have image files",
+  ).toHaveLength(1);
+  expect(
+    zip.file(/www\/sentence\-paragr\-[0-9]*\.txt/),
+    "should have readalong plain text file",
+  ).toHaveLength(1);
+  expect(zip.file(/www\/readme.txt/), "should have readme file").toHaveLength(
+    1,
+  );
+  expect(zip.file(/www\/index.html/), "should have index file").toHaveLength(1);
+}

--- a/packages/studio-web/tests/editor/use-audio-toolbar.spec.ts
+++ b/packages/studio-web/tests/editor/use-audio-toolbar.spec.ts
@@ -62,7 +62,7 @@ test("should edit alignment and words (editor)", async ({ page, isMobile }) => {
     .evaluate((seg) => (seg as HTMLElement).title.substring(0, 4));
 
   //check web bundle output
-  await page.locator("#mat-select-value-3").click();
+  await page.getByTestId("download-formats").click();
   await page.getByRole("option", { name: "Web Bundle" }).click();
   let downloadPromise = page.waitForEvent("download");
   await page.getByTestId("download-ras").click();
@@ -90,7 +90,7 @@ test("should edit alignment and words (editor)", async ({ page, isMobile }) => {
     .toMatch(new RegExp(`time="${newStartTime.replace(".", "\\.")}\\d+" `));
 
   //check SRT
-  await page.locator("#mat-select-value-3").click();
+  await page.getByTestId("download-formats").click();
   await page.getByRole("option", { name: "SRT Subtitles" }).click();
   downloadPromise = page.waitForEvent("download");
   await page.getByTestId("download-ras").click();
@@ -110,7 +110,7 @@ test("should edit alignment and words (editor)", async ({ page, isMobile }) => {
     )
     .toMatch(new RegExp(`${newStartTime.replace(".", ",")}\\d+\\s-->`));
   //check WEBVTT
-  await page.locator("#mat-select-value-3").click();
+  await page.getByTestId("download-formats").click();
   await page.getByRole("option", { name: "WebVTT Subtitles" }).click();
   downloadPromise = page.waitForEvent("download");
   await page.getByTestId("download-ras").click();
@@ -127,7 +127,7 @@ test("should edit alignment and words (editor)", async ({ page, isMobile }) => {
     )
     .toMatch(new RegExp(`${newStartTime.replace(".", "\\.")}\\d+\\s-->`));
   //check PRAAT
-  await page.locator("#mat-select-value-3").click();
+  await page.getByTestId("download-formats").click();
   await page.getByRole("option", { name: "Praat TextGrid" }).click();
   downloadPromise = page.waitForEvent("download");
   await page.getByTestId("download-ras").click();
@@ -146,7 +146,7 @@ test("should edit alignment and words (editor)", async ({ page, isMobile }) => {
       new RegExp(`xmin\\s=\\s${newStartTime.replace(".", "\\.")}\\d+\\\s`),
     );
   //check elan
-  await page.locator("#mat-select-value-3").click();
+  await page.getByTestId("download-formats").click();
   await page.getByRole("option", { name: "Elan File" }).click();
   downloadPromise = page.waitForEvent("download");
   await page.getByTestId("download-ras").click();

--- a/packages/studio-web/tests/studio-web/download-elan.spec.ts
+++ b/packages/studio-web/tests/studio-web/download-elan.spec.ts
@@ -5,7 +5,7 @@ test("should Download ELAN ( file format)", async ({ page, browserName }) => {
   await defaultBeforeEach(page, browserName);
   await testMakeAReadAlong(page);
 
-  await page.locator("#mat-select-value-3").click();
+  await page.getByTestId("download-formats").click();
   await page.getByRole("option", { name: "Elan File" }).click();
   const download2Promise = page.waitForEvent("download");
   await page.getByTestId("download-ras").click();

--- a/packages/studio-web/tests/studio-web/download-praat.spec.ts
+++ b/packages/studio-web/tests/studio-web/download-praat.spec.ts
@@ -11,7 +11,7 @@ test("should Download Praat ( file format)", async ({ page, browserName }) => {
   await defaultBeforeEach(page, browserName);
   await testMakeAReadAlong(page);
 
-  await page.locator("#mat-select-value-3").click();
+  await page.getByTestId("download-formats").click();
   await page.getByRole("option", { name: "Praat TextGrid" }).click();
   const download2Promise = page.waitForEvent("download");
   await page.getByTestId("download-ras").click();

--- a/packages/studio-web/tests/studio-web/download-srt.spec.ts
+++ b/packages/studio-web/tests/studio-web/download-srt.spec.ts
@@ -11,7 +11,7 @@ test("should Download SRT ( file format)", async ({ page, browserName }) => {
   await defaultBeforeEach(page, browserName);
   await testMakeAReadAlong(page);
 
-  await page.locator("#mat-select-value-3").click();
+  await page.getByTestId("download-formats").click();
   await page.getByRole("option", { name: "SRT Subtitles" }).click();
   const download2Promise = page.waitForEvent("download");
   await page.getByTestId("download-ras").click();

--- a/packages/studio-web/tests/studio-web/download-web-bundle.spec.ts
+++ b/packages/studio-web/tests/studio-web/download-web-bundle.spec.ts
@@ -15,7 +15,7 @@ test("should Download web bundle (zip file format)", async ({
   //download web bundle
   await page.getByLabel("2Step").locator("svg").click();
   await page.locator(".cdk-overlay-backdrop").click();
-  await page.locator("#mat-select-value-3").click();
+  await page.getByTestId("download-formats").click();
   await page.getByRole("option", { name: "Web Bundle" }).click();
   const download1Promise = page.waitForEvent("download");
   await page.getByTestId("download-ras").click();

--- a/packages/studio-web/tests/studio-web/download-webvtt.spec.ts
+++ b/packages/studio-web/tests/studio-web/download-webvtt.spec.ts
@@ -13,7 +13,7 @@ test("should Download WebVTT ( file format)", async ({ page, browserName }) => {
   await defaultBeforeEach(page, browserName);
   await testMakeAReadAlong(page);
 
-  await page.locator("#mat-select-value-3").click();
+  await page.getByTestId("download-formats").click();
   await page.getByRole("option", { name: "WebVTT Subtitles" }).click();
   const download2Promise = page.waitForEvent("download");
   await page.getByTestId("download-ras").click();


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Fixes the broken (or missing) text file when a bundle is generated from the Editor component.

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

Fixes #392 

### Feedback sought? <!-- What should reviewers focus on in particular? -->


### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

Anytime, non-blocking.

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

Yes, added a single web bundle download test for the Editor component.

### How to test? <!-- Explain how reviewers should test this PR. -->

From the Editor: 
- upload a previously generated HTML readalong file. 
- download a web bundle
- the generated web bundle should now contain a text file under the `www/` directory with the original user provided text.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

Fairly confident.


### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->



<!-- Add any other relevant information here -->
