### PR TITLE
test: skip flaky mobile chrome test

### DIFF
--- a/packages/studio-web/tests/editor/use-audio-toolbar.spec.ts
+++ b/packages/studio-web/tests/editor/use-audio-toolbar.spec.ts
@@ -5,6 +5,10 @@ import JSZip from "jszip";
 test.describe.configure({ mode: "parallel" });
 
 test("should edit alignment and words (editor)", async ({ page, isMobile }) => {
+  // See issue #405 - this test is flaky with Mobile Chrome. Disabled until
+  // it can be stabilized.
+  test.skip(Boolean(isMobile), "skipping flaky Mobile Chrome test.");
+
   await expect(async () => {
     await editorDefaultBeforeEach(page, isMobile);
   }).toPass();


### PR DESCRIPTION
As discussed, disables a flaky mobile chrome test. See #405 for more information.