### PR TITLE
fix: standardized export file names across all export formats

### DIFF
--- a/packages/studio-web/src/app/shared/download/download.service.ts
+++ b/packages/studio-web/src/app/shared/download/download.service.ts
@@ -250,8 +250,7 @@ Please host all assets on your server, include the font and package imports defi
   }
 
   createRASBasename(title: string) {
-    const timestamp = new Date()
-      .toISOString()
+    const timestamp = dateToLocalISO(new Date())
       .replace(/[^0-9]/g, "")
       .slice(0, -3);
     return (title ? slugify(title, 15) : "readalong") + `-${timestamp}`;
@@ -439,6 +438,8 @@ Use the text editor to paste the snippet below in your WordPress page:
       );
       this.registerDownloadEvent(selectedOutputFormat, from);
     } else {
+      const basename = this.createRASBasename(slots.title);
+
       let audio: HTMLAudioElement = new Audio(b64Audio);
       // - update .readalong file translation
       await this.updateTranslations(rasXML, readalong);
@@ -453,7 +454,7 @@ Use the text editor to paste the snippet below in your WordPress page:
         )
         .pipe(takeUntil(this.unsubscribe$))
         .subscribe({
-          next: (x: Blob) => saveAs(x, `readalong.${selectedOutputFormat}`),
+          next: (x: Blob) => saveAs(x, `${basename}.${selectedOutputFormat}`),
           error: (err: HttpErrorResponse) => this.reportRasError(err),
         });
 
@@ -527,4 +528,16 @@ Use the text editor to paste the snippet below in your WordPress page:
 
     return output.join("");
   }
+}
+
+// Converts the date to an ISO string set to the user's local timezone.
+//
+// Date.toISOString() returns a string with the time set to UTC. This code is
+// extracted from the following stack overflow question:
+//   https://stackoverflow.com/questions/12413243/javascript-date-format-like-iso-but-local
+function dateToLocalISO(date: Date) {
+  const offsetMs = date.getTimezoneOffset() * 60 * 1000;
+  const localInMs = date.getTime() - offsetMs;
+  const dateLocal = new Date(localInMs);
+  return dateLocal.toISOString();
 }

--- a/packages/studio-web/tests/studio-web/download-elan.spec.ts
+++ b/packages/studio-web/tests/studio-web/download-elan.spec.ts
@@ -13,5 +13,5 @@ test("should Download ELAN ( file format)", async ({ page, browserName }) => {
   await expect(
     download2.suggestedFilename(),
     "should have the expected filename",
-  ).toMatch(/readalong\.eaf/);
+  ).toMatch(/sentence\-paragr\-[0-9]*\.eaf/);
 });

--- a/packages/studio-web/tests/studio-web/download-praat.spec.ts
+++ b/packages/studio-web/tests/studio-web/download-praat.spec.ts
@@ -19,7 +19,7 @@ test("should Download Praat ( file format)", async ({ page, browserName }) => {
   await expect(
     download2.suggestedFilename(),
     "should have the expected filename",
-  ).toMatch(/readalong\.textgrid/);
+  ).toMatch(/sentence\-paragr\-[0-9]*\.textgrid/);
   /* check output*/
   const filePath = await download2.path();
   const fileData = fs.readFileSync(filePath, { encoding: "utf8", flag: "r" });

--- a/packages/studio-web/tests/studio-web/download-srt.spec.ts
+++ b/packages/studio-web/tests/studio-web/download-srt.spec.ts
@@ -19,7 +19,7 @@ test("should Download SRT ( file format)", async ({ page, browserName }) => {
   await expect(
     download2.suggestedFilename(),
     "should have the expected filename",
-  ).toMatch(/readalong\.srt/);
+  ).toMatch(/sentence\-paragr\-[0-9]*\.srt/);
 
   const filePath = await download2.path();
   const fileData = fs.readFileSync(filePath, { encoding: "utf8", flag: "r" });

--- a/packages/studio-web/tests/studio-web/download-webvtt.spec.ts
+++ b/packages/studio-web/tests/studio-web/download-webvtt.spec.ts
@@ -21,7 +21,7 @@ test("should Download WebVTT ( file format)", async ({ page, browserName }) => {
   await expect(
     download2.suggestedFilename(),
     "should have the expected filename",
-  ).toMatch(/readalong\.vtt/);
+  ).toMatch(/sentence\-paragr\-[0-9]*\.vtt/);
   // check output
   const filePath = await download2.path();
   const fileData = fs.readFileSync(filePath, { encoding: "utf8", flag: "r" });


### PR DESCRIPTION
### PR Goal? <!-- Explain the main objective of this PR. -->

Fixes #366 by standardizing the export filenames across all download types. Additionally, it now uses a timestamp set to the user's local timezone, instead of UTC.


### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

Small fix and non-blocking, not urgent.

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

Updated existing test to verify new file name format.

### How to test? <!-- Explain how reviewers should test this PR. -->

Create a new ReadAlong or upload an existing one in the Editor. Download one of the following formats: eaf/srt/vtt/textgrid. The download file should follow the same naming convention as "Offline HTML" and "Web Bundle" which is:

`{readalong-title}-{timestamp}.{extension}`

The `timestamp` portion should also be in your local timezone (instead of UTC).

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

It is ready to merge.


### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->



<!-- Add any other relevant information here -->
