### PR TITLE
fix: corrected Sass @import deprecation warning

### DIFF
--- a/packages/studio-web/src/styles.sass
+++ b/packages/studio-web/src/styles.sass
@@ -1,7 +1,9 @@
+// We use ngx-toastr for pop-up errors, warnings and informative messages
+@use 'ngx-toastr/toastr'
+
 /* You can add global styles to this file, and also import other style files */
 @import '@angular/material/prebuilt-themes/indigo-pink.css'
-// We use ngx-toastr for pop-up errors, warnings and informative messages
-@import 'ngx-toastr/toastr'
+
 // The studio-web layout is built using Bootstrap 5
 @import 'bootstrap/dist/css/bootstrap.min.css'
 // We use shepherd for the guided tour


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Corrects the Sass `@import` deprecation warning in Studio Web.


### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

#412 

### Feedback sought? <!-- What should reviewers focus on in particular? -->



### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

Not urgent, non-blocking and @import's support is still available.

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

None required.

### How to test? <!-- Explain how reviewers should test this PR. -->

I've confirmed the deprecation warning is gone. The @import issue was only for ngx-toastr library, so validating that toaster messages are still getting CSS styling would confirm the `@use` statement works correctly.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

High.


### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->



<!-- Add any other relevant information here -->
