### PR TITLE
fix: added button to switch between English and French

### DIFF
--- a/.github/workflows/dev-preview.yml
+++ b/.github/workflows/dev-preview.yml
@@ -29,6 +29,7 @@ jobs:
           npx nx test:once studio-web
       - name: Build
         run: |
+          sed -r -i  's:readalong-studio.mothertongues.org/:readalong-studio.mothertongues.org/dev/:g' packages/studio-web/src/environments/environment.prod.ts
           npx nx build studio-web --configuration=production --base-href=/dev/
           npx nx build studio-web --configuration=production --base-href=/dev/ --localize=fr --deleteOutputPath=false
           npx nx build studio-web --configuration=production --base-href=/dev/ --localize=es --deleteOutputPath=false

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Build
         if: github.event.action != 'closed'
         run: |
+          sed -r -i  's:readalong-studio.mothertongues.org/:readalong-studio.mothertongues.org/pr-preview/pr-${{github.event.number}}/:g' packages/studio-web/src/environments/environment.prod.ts
           npx nx build studio-web --base-href=/pr-preview/pr-${{github.event.number}}/ --configuration=production
           npx nx build studio-web --base-href=/pr-preview/pr-${{github.event.number}}/ --configuration=production --localize=fr --deleteOutputPath=false
           npx nx build studio-web --base-href=/pr-preview/pr-${{github.event.number}}/ --configuration=production --localize=es --deleteOutputPath=false

--- a/packages/studio-web/src/app/app.component.html
+++ b/packages/studio-web/src/app/app.component.html
@@ -14,7 +14,7 @@
   <mat-menu #menu="matMenu">
     <button
       mat-menu-item
-      [class]="currentURL() === '/' ? 'accent' : ''"
+      [class]="currentURL() === '/' ? 'mat-accent mat-mdc-button' : ''"
       [routerLink]="''"
     >
       <mat-icon>home</mat-icon>
@@ -24,7 +24,7 @@
       id="goToEditor"
       class="plausible-event-name=Editor"
       mat-menu-item
-      [class]="currentURL() === '/editor' ? 'accent' : ''"
+      [class]="currentURL() === '/editor' ? 'mat-accent mat-mdc-button' : ''"
       [routerLink]="'editor'"
     >
       <mat-icon>edit</mat-icon>
@@ -43,8 +43,10 @@
         title="{{ lang.title }}"
         (click)="switchLanguage(`${lang.url}#${currentURL()}`)"
       >
-        <span class="text-icon">{{ lang.code }}</span>
-        <span>{{ lang.name }}</span>
+        <div style="display: flex">
+          <span class="mat-icon text-icon">{{ lang.code }}</span>
+          <span>{{ lang.name }}</span>
+        </div>
       </button>
     }
   </mat-menu>

--- a/packages/studio-web/src/app/app.component.html
+++ b/packages/studio-web/src/app/app.component.html
@@ -13,35 +13,46 @@
   </button>
   <mat-menu #menu="matMenu">
     <button
-      mat-button
-      [color]="currentURL === '/' ? 'accent' : ''"
+      mat-menu-item
+      [class]="currentURL() === '/' ? 'accent' : ''"
       [routerLink]="''"
     >
       <mat-icon>home</mat-icon>
       <span i18n="Studio">Studio</span>
     </button>
-    <br />
     <button
       id="goToEditor"
       class="plausible-event-name=Editor"
-      mat-button
-      [color]="currentURL === '/editor' ? 'accent' : ''"
+      mat-menu-item
+      [class]="currentURL() === '/editor' ? 'accent' : ''"
       [routerLink]="'editor'"
     >
       <mat-icon>edit</mat-icon>
       <span i18n="Editor">Editor</span>
     </button>
-    <br />
-    <button mat-button (click)="openPrivacyDialog()">
+    <button mat-menu-item (click)="openPrivacyDialog()">
       <mat-icon>policy</mat-icon>
       <span i18n="Privacy">Privacy</span>
     </button>
+    <mat-divider />
+    @for (lang of languages; track lang.code) {
+      <button
+        mat-menu-item
+        lang="{{ lang.code }}"
+        translate="no"
+        title="{{ lang.title }}"
+        (click)="switchLanguage(`${lang.url}#${currentURL()}`)"
+      >
+        <span class="text-icon">{{ lang.code }}</span>
+        <span>{{ lang.name }}</span>
+      </button>
+    }
   </mat-menu>
   <div class="nav__buttons d-none d-md-block">
     <button
       class="nav__button"
       mat-button
-      [color]="currentURL === '/' ? 'accent' : ''"
+      [color]="currentURL() === '/' ? 'accent' : ''"
       [routerLink]="''"
     >
       <mat-icon>home</mat-icon>
@@ -51,7 +62,7 @@
       id="goToEditor"
       class="nav__button plausible-event-name=Editor"
       mat-button
-      [color]="currentURL === '/editor' ? 'accent' : ''"
+      [color]="currentURL() === '/editor' ? 'accent' : ''"
       [routerLink]="'editor'"
     >
       <mat-icon>edit</mat-icon>
@@ -61,6 +72,23 @@
       <mat-icon>policy</mat-icon>
       <span i18n="Privacy">Privacy</span>
     </button>
+
+    <span class="mat-mdc-button">
+      @for (lang of languages; track lang.code) {
+        <a
+          lang="{{ lang.code }}"
+          translate="no"
+          target="_blank"
+          title="{{ lang.title }}"
+          href="{{ lang.url }}#{{ currentURL() }}"
+          class="language-selection"
+          >{{ lang.code }}</a
+        >
+        @if (!$last) {
+          |
+        }
+      }
+    </span>
   </div>
 </mat-toolbar>
 <router-outlet></router-outlet>

--- a/packages/studio-web/src/app/app.component.sass
+++ b/packages/studio-web/src/app/app.component.sass
@@ -17,16 +17,10 @@
 .language-selection
   text-transform: capitalize
 
-.accent
-  color: #ff4081
-
-.accent > .mat-icon
+.mat-accent > .mat-icon
   color: inherit
 
 span.text-icon
   font-weight: bold
-  width: 24px
-  display: inline-block
-  margin-right: 12px
-  flex-shrink: 0
-  text-transform: uppercase
+  text-align: center
+  text-transform: capitalize

--- a/packages/studio-web/src/app/app.component.sass
+++ b/packages/studio-web/src/app/app.component.sass
@@ -13,3 +13,20 @@
 
 .nav-spacer
   flex: 1 1 auto
+
+.language-selection
+  text-transform: capitalize
+
+.accent
+  color: #ff4081
+
+.accent > .mat-icon
+  color: inherit
+
+span.text-icon
+  font-weight: bold
+  width: 24px
+  display: inline-block
+  margin-right: 12px
+  flex-shrink: 0
+  text-transform: uppercase

--- a/packages/studio-web/src/app/app.component.ts
+++ b/packages/studio-web/src/app/app.component.ts
@@ -1,6 +1,6 @@
 import { Subject, takeUntil } from "rxjs";
 import { MatDialogRef, MatDialog } from "@angular/material/dialog";
-import { Component, OnDestroy, OnInit } from "@angular/core";
+import { Component, OnDestroy, OnInit, signal } from "@angular/core";
 import { environment } from "../environments/environment";
 import { Router } from "@angular/router";
 @Component({
@@ -12,15 +12,23 @@ import { Router } from "@angular/router";
 export class AppComponent implements OnDestroy, OnInit {
   unsubscribe$ = new Subject<void>();
   version = environment.packageJson.singleFileBundleVersion;
-  currentURL = "/";
+  currentURL = signal("/");
+  languages: (typeof environment)["languages"];
+
   constructor(
     private dialog: MatDialog,
     public router: Router,
-  ) {}
+  ) {
+    const currentLanguage = $localize.locale ?? "en";
+    this.languages = environment.languages.filter(
+      (l) => l.code != currentLanguage,
+    );
+  }
+
   ngOnInit(): void {
     this.router.events.pipe(takeUntil(this.unsubscribe$)).subscribe((event) => {
       if (event.type === 1) {
-        this.currentURL = event.url;
+        this.currentURL.set(event.url);
       }
     });
   }
@@ -32,6 +40,10 @@ export class AppComponent implements OnDestroy, OnInit {
       minWidth: "60vw",
       maxHeight: "95vh",
     });
+  }
+
+  switchLanguage(url: string) {
+    window.open(url, "_blank");
   }
 
   ngOnDestroy(): void {

--- a/packages/studio-web/src/app/material.module.ts
+++ b/packages/studio-web/src/app/material.module.ts
@@ -11,6 +11,7 @@ import { MatSelectModule } from "@angular/material/select";
 import { MatSlideToggleModule } from "@angular/material/slide-toggle";
 import { MatStepperModule } from "@angular/material/stepper";
 import { MatMenuModule } from "@angular/material/menu";
+import { MatDividerModule } from "@angular/material/divider";
 
 @NgModule({
   imports: [
@@ -28,6 +29,7 @@ import { MatMenuModule } from "@angular/material/menu";
     MatButtonToggleModule,
   ],
   exports: [
+    MatDividerModule,
     MatStepperModule,
     MatFormFieldModule,
     MatSlideToggleModule,

--- a/packages/studio-web/src/app/studio/studio.component.ts
+++ b/packages/studio-web/src/app/studio/studio.component.ts
@@ -1,5 +1,5 @@
 import { ShepherdService } from "../shepherd.service";
-import { forkJoin, of, BehaviorSubject, Subject, take, takeUntil } from "rxjs";
+import { forkJoin, of, Subject, take, takeUntil } from "rxjs";
 import { Segment } from "soundswallower";
 
 import { Component, OnDestroy, OnInit, ViewChild } from "@angular/core";
@@ -40,6 +40,7 @@ import { StepperSelectionEvent } from "@angular/cdk/stepper";
 import { HttpErrorResponse } from "@angular/common/http";
 import { DownloadService } from "../shared/download/download.service";
 import { StudioService } from "./studio.service";
+import { environment } from "../../environments/environment";
 
 @Component({
   selector: "studio-component",
@@ -108,10 +109,13 @@ export class StudioComponent implements OnDestroy, OnInit {
     );
 
     // User Browser's default messaging to warn the user when they're about to leave the page
-    window.addEventListener("beforeunload", (e) => {
-      if (this.formIsDirty()) (e || window.event).returnValue = true;
-      return true;
-    });
+    if (environment.production) {
+      window.addEventListener("beforeunload", (e) => {
+        if (this.formIsDirty()) (e || window.event).returnValue = true;
+        return true;
+      });
+    }
+
     // Catch and report a catastrophic failure as soon as possible
     this.ssjsService
       .loadModule$()

--- a/packages/studio-web/src/environments/environment.prod.ts
+++ b/packages/studio-web/src/environments/environment.prod.ts
@@ -4,4 +4,25 @@ export const environment = {
   production: true,
   apiBaseURL: "https://readalong-studio.herokuapp.com/api/v1",
   packageJson: packageJson,
+
+  languages: [
+    {
+      code: "en",
+      url: "https://readalong-studio.mothertongues.org/",
+      title: "Start a new session in English.",
+      name: "English",
+    },
+    {
+      code: "fr",
+      url: "https://readalong-studio.mothertongues.org/fr/",
+      title: "Démarrer une nouvelle session en français.",
+      name: "Français",
+    },
+    {
+      code: "es",
+      url: "https://readalong-studio.mothertongues.org/es/",
+      title: "Iniciar una nueva sesión en español.",
+      name: "Español",
+    },
+  ],
 };

--- a/packages/studio-web/src/environments/environment.ts
+++ b/packages/studio-web/src/environments/environment.ts
@@ -7,6 +7,27 @@ export const environment = {
   production: false,
   apiBaseURL: "http://localhost:8000/api/v1",
   packageJson: packageJson,
+
+  languages: [
+    {
+      code: "en",
+      url: "http://localhost:4200/",
+      title: "Start a new session in English.",
+      name: "English",
+    },
+    {
+      code: "fr",
+      url: "http://localhost:4203/",
+      title: "Démarrer une nouvelle session en français.",
+      name: "Français",
+    },
+    {
+      code: "es",
+      url: "http://localhost:4204/",
+      title: "Iniciar una nueva sesión en español.",
+      name: "Español",
+    },
+  ],
 };
 
 /*

--- a/packages/studio-web/tests/editor/change-language.spec.ts
+++ b/packages/studio-web/tests/editor/change-language.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from "@playwright/test";
+import { disablePlausible } from "../test-commands";
+
+test.describe("test editor UI language selection", () => {
+  test("should switch to French version", async ({ page, isMobile }) => {
+    await page.goto("/#editor/");
+    await disablePlausible(page);
+
+    const popupPromise = page.waitForEvent("popup");
+    if (!isMobile) {
+      await page
+        .locator("a.language-selection")
+        .filter({ hasText: "fr" })
+        .click();
+    } else {
+      await page.getByTestId("menu-toggle").click();
+      await page.getByRole("menuitem", { name: /Français/ }).click();
+    }
+
+    const popupPage = await popupPromise;
+    await expect(
+      popupPage.getByText("Choisissez un fichier HTML ReadAlong."),
+    ).toBeVisible();
+  });
+
+  test("should switch to Spanish version", async ({ page, isMobile }) => {
+    await page.goto("/#editor/");
+    await disablePlausible(page);
+
+    const popupPromise = page.waitForEvent("popup");
+    if (!isMobile) {
+      await page
+        .locator("a.language-selection")
+        .filter({ hasText: "es" })
+        .click();
+    } else {
+      await page.getByTestId("menu-toggle").click();
+      await page.getByRole("menuitem", { name: /Español/ }).click();
+    }
+
+    const popupPage = await popupPromise;
+    await expect(
+      popupPage.getByText("Seleccione un documento HTML offline de ReadAlong."),
+    ).toBeVisible();
+  });
+
+  test("should switch to English version", async ({ page, isMobile }) => {
+    await page.goto("http://localhost:4203/#/editor");
+    await disablePlausible(page);
+
+    const popupPromise = page.waitForEvent("popup");
+    if (!isMobile) {
+      await page
+        .locator("a.language-selection")
+        .filter({ hasText: "en" })
+        .click();
+    } else {
+      await page.getByTestId("menu-toggle").click();
+      await page.getByRole("menuitem", { name: /English/ }).click();
+    }
+
+    const popupPage = await popupPromise;
+    await expect(
+      popupPage.getByText("Select an offline HTML ReadAlong file."),
+    ).toBeVisible();
+  });
+});

--- a/packages/studio-web/tests/editor/check-page.spec.ts
+++ b/packages/studio-web/tests/editor/check-page.spec.ts
@@ -8,7 +8,9 @@ test("should check editor UI", async ({ page, isMobile }) => {
   if (isMobile) {
     await page.getByTestId("menu-toggle").click();
   }
-  await page.getByRole("button", { name: /Editor/ }).click();
+  await page
+    .getByRole(isMobile ? "menuitem" : "button", { name: /Editor/ })
+    .click();
   await expect(
     page.getByRole("button", { name: "Take the tour!" }),
     "Tour button is visible",
@@ -101,7 +103,9 @@ test("should verify the uploaded file type", async ({ page, isMobile }) => {
   if (isMobile) {
     await page.getByTestId("menu-toggle").click();
   }
-  await page.getByRole("button", { name: /Editor/ }).click();
+  await page
+    .getByRole(isMobile ? "menuitem" : "button", { name: /Editor/ })
+    .click();
   await expect(
     page.getByRole("button", { name: "Take the tour!" }),
     "Tour button is visible",

--- a/packages/studio-web/tests/editor/download-web-bundle.spec.ts
+++ b/packages/studio-web/tests/editor/download-web-bundle.spec.ts
@@ -13,7 +13,9 @@ test("should Download web bundle (zip file format) from the Editor", async ({
   if (isMobile) {
     await page.getByTestId("menu-toggle").click();
   }
-  await page.getByRole("button", { name: /Editor/ }).click();
+  await page
+    .getByRole(isMobile ? "menuitem" : "button", { name: /Editor/ })
+    .click();
 
   await expect(
     page.locator("#updateRAS"),

--- a/packages/studio-web/tests/editor/tour-editor.spec.ts
+++ b/packages/studio-web/tests/editor/tour-editor.spec.ts
@@ -7,7 +7,9 @@ test("should do tour", async ({ page, isMobile }) => {
   if (isMobile) {
     await page.getByTestId("menu-toggle").click();
   }
-  await page.getByRole("button", { name: /Editor/ }).click();
+  await page
+    .getByRole(isMobile ? "menuitem" : "button", { name: /Editor/ })
+    .click();
   await expect(
     page.getByRole("button", { name: "Take the tour!" }),
     "Tour button is visible",

--- a/packages/studio-web/tests/studio-web/change-language.spec.ts
+++ b/packages/studio-web/tests/studio-web/change-language.spec.ts
@@ -1,0 +1,77 @@
+import { test, expect } from "@playwright/test";
+import { disablePlausible } from "../test-commands";
+
+test.describe("test studio UI language selection", () => {
+  test("should switch to French version", async ({ page, isMobile }) => {
+    await page.goto("/");
+    await disablePlausible(page);
+
+    const popupPromise = page.waitForEvent("popup");
+    if (!isMobile) {
+      await page
+        .locator("a.language-selection")
+        .filter({ hasText: "fr" })
+        .click();
+    } else {
+      await page.getByTestId("menu-toggle").click();
+      await page.getByRole("menuitem", { name: /Français/ }).click();
+    }
+
+    const popupPage = await popupPromise;
+
+    // unique to studio web, and contains French text
+    await expect(
+      popupPage.getByRole("radio", {
+        name: "Sélectionner une langue spécifique",
+      }),
+    ).toBeVisible();
+  });
+
+  test("should switch to Spanish version", async ({ page, isMobile }) => {
+    await page.goto("/");
+    await disablePlausible(page);
+
+    const popupPromise = page.waitForEvent("popup");
+    if (!isMobile) {
+      await page
+        .locator("a.language-selection")
+        .filter({ hasText: "es" })
+        .click();
+    } else {
+      await page.getByTestId("menu-toggle").click();
+      await page.getByRole("menuitem", { name: /Español/ }).click();
+    }
+
+    const popupPage = await popupPromise;
+
+    // unique to studio web, and contains Spanish text
+    await expect(
+      popupPage.getByRole("radio", {
+        name: "Seleccione un idioma específico",
+      }),
+    ).toBeVisible();
+  });
+
+  test("should switch to English version", async ({ page, isMobile }) => {
+    await page.goto("http://localhost:4203/");
+    await disablePlausible(page);
+
+    const popupPromise = page.waitForEvent("popup");
+    if (!isMobile) {
+      await page
+        .locator("a.language-selection")
+        .filter({ hasText: "en" })
+        .click();
+    } else {
+      await page.getByTestId("menu-toggle").click();
+      await page.getByRole("menuitem", { name: /English/ }).click();
+    }
+
+    const popupPage = await popupPromise;
+
+    // unique to studio web, and contains english text
+    await expect(
+      popupPage.getByRole("radio", { name: "Select a specific language" }),
+    ).toBeVisible();
+  });
+});

--- a/packages/studio-web/tests/test-commands.ts
+++ b/packages/studio-web/tests/test-commands.ts
@@ -145,7 +145,9 @@ export const editorDefaultBeforeEach = async (
     if (isMobile) {
       await page.getByTestId("menu-toggle").click();
     }
-    await page.getByRole("button", { name: /Editor/ }).click();
+    await page
+      .getByRole(isMobile ? "menuitem" : "button", { name: /Editor/ })
+      .click();
 
     await page.locator("#updateRAS").waitFor({ state: "visible" });
     let fileChooserPromise = page.waitForEvent("filechooser");


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Adds controls to Studio Web to switch between English, French and Spanish versions.

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

Closes #156 

### Feedback sought? <!-- What should reviewers focus on in particular? -->

- General design feedback and validation it works as expected.
- Opinions on language acronyms and their display: titlecase (En) vs uppercase (EN) vs lowercase (en)
- Cannot use `$localize` for this work, text for these 3 languages have been encoded in `environment.ts` and **duplicated** in `environment.prod.ts`. We could extract most of the information to a `environment/ui-languages.json` file, and limit the environment.*.ts files to only the URL details.

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

Medium, non blocker.

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

Yes, end-to-end tests for language switching: en->fr, en->es, fr->en for both Studio Web and Editor.

### How to test? <!-- Explain how reviewers should test this PR. -->

- Clicking on a language link (Fr, Es, En) should open studio web in a new tab in that language.
- The currently active component (Studio or Editor) is expected to be active in the other language tab. 
- Responsive design: these language links have been added to the responsive menu while using narrow viewports (mobile).

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

High.

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

<!-- Add any other relevant information here -->
