### PR TITLE
fix: limit calls to assemble api on sound swallower retries

### DIFF
--- a/packages/studio-web/src/app/upload/upload.component.ts
+++ b/packages/studio-web/src/app/upload/upload.component.ts
@@ -13,6 +13,8 @@ import {
   map,
   takeUntil,
   throwError,
+  firstValueFrom,
+  take,
 } from "rxjs";
 
 import {
@@ -437,16 +439,19 @@ Please check it to make sure all words are spelled out completely, e.g. write "4
           this.studioService.audioControl$.value as File,
           8000,
         ),
-        ras: this.fileService
-          .readFile$(this.studioService.textControl$.value)
-          .pipe(
-            switchMap((text: string): Observable<ReadAlong> => {
-              body.input = text;
-              this.progressMode = "determinate";
-              this.progressValue = 0;
-              return this.rasService.assembleReadalong$(body);
-            }),
-          ),
+        ras: firstValueFrom(
+          this.fileService
+            .readFile$(this.studioService.textControl$.value)
+            .pipe(
+              switchMap((text: string): Observable<ReadAlong> => {
+                body.input = text;
+                this.progressMode = "determinate";
+                this.progressValue = 0;
+                return this.rasService.assembleReadalong$(body);
+              }),
+              take(1),
+            ),
+        ),
       })
         .pipe(
           switchMap(


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Eliminates multiple redundant calls to the `/assemble` API. 

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

Closes #383 

### Feedback sought? <!-- What should reviewers focus on in particular? -->

- Confirmation that it works as expected.
- Not very knowledgeable of RxJS, confirmation this is the correct approach. 

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

Low, non-blocking.

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

None.

### How to test? <!-- Explain how reviewers should test this PR. -->

Follow Eric's instructions from the issue:

> To reproduce, watch the network requests with F12 in Chrome, load a big text file, record a couple seconds of noise, and then click go to next step.
>
> You'll see in the network traffic that assemble is called again from the backend three times, even though it's getting exactly the same output back each time.

Now instead of seeing multiple calls to assemble, there should a single call.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

High.

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->



<!-- Add any other relevant information here -->
