### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/packages/studio-web/package.json
+++ b/packages/studio-web/package.json
@@ -18,6 +18,7 @@
   "singleFileBundleVersion": "1.5.2",
   "singleFileBundleTimestamp": "2024-11-18+11-19-49",
   "dependencies": {
-    "readalong-studio": "file:"
+    "readalong-studio": "file:",
+    "dompurify": "^3.2.6"
   }
 }

--- a/packages/studio-web/src/app/editor/editor.component.ts
+++ b/packages/studio-web/src/app/editor/editor.component.ts
@@ -1,6 +1,7 @@
 import WaveSurfer from "wavesurfer.js";
 
 import { takeUntil, Subject, take } from "rxjs";
+import DOMPurify from "dompurify";
 import {
   AfterViewInit,
   Component,
@@ -285,7 +286,8 @@ export class EditorComponent implements OnDestroy, OnInit, AfterViewInit {
     // don't expect to always find them.
 
     const parser = new DOMParser();
-    const readalong = parser.parseFromString(text, "text/html");
+    const sanitizedText = DOMPurify.sanitize(text);
+    const readalong = parser.parseFromString(sanitizedText, "text/html");
     const element = readalong.querySelector("read-along");
 
     if (element === undefined || element === null) {


### PR DESCRIPTION
Potential fix for [https://github.com/ReadAlongs/Studio-Web/security/code-scanning/2](https://github.com/ReadAlongs/Studio-Web/security/code-scanning/2)

To fix the issue, the input data (`text`) should be sanitized or validated before being passed to `DOMParser.parseFromString()`. This ensures that any potentially malicious content is neutralized. The best approach is to use a library designed for sanitizing HTML, such as `DOMPurify`, which can remove unsafe elements and attributes from the input.

**Steps to implement the fix:**
1. Install the `dompurify` library to sanitize the input.
2. Import `DOMPurify` into the file.
3. Use `DOMPurify.sanitize()` to sanitize the `text` variable before passing it to `DOMParser.parseFromString()`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
