### PR TITLE
fix: studio tour shows incorrect user preview 

### DIFF
--- a/packages/studio-web/src/app/editor/editor.component.ts
+++ b/packages/studio-web/src/app/editor/editor.component.ts
@@ -385,14 +385,6 @@ export class EditorComponent implements OnDestroy, OnInit, AfterViewInit {
         .pipe(takeUntil(this.unsubscribe$))
         .subscribe(async (indexFile) => {
           await this.loadRasFile(indexFile);
-          console.log(
-            document
-              .querySelector("#wavesurferContainer")
-              ?.querySelector(".segment-content"),
-            document
-              .querySelector("#readalongContainer")
-              ?.querySelector("read-along"),
-          );
           this.shepherdService.next();
           readalong_add_image_step["attachTo"] = {
             element: document

--- a/packages/studio-web/src/app/shepherd.steps.ts
+++ b/packages/studio-web/src/app/shepherd.steps.ts
@@ -425,7 +425,7 @@ export const readalong_editor_choose_file: any = {
     },
     {
       classes: "shepherd-button-warning",
-      text: $localize`Next`,
+      text: $localize`Next` + " " + $localize`(overwrites your data)`,
     },
   ],
 };

--- a/packages/studio-web/src/app/studio/studio.component.ts
+++ b/packages/studio-web/src/app/studio/studio.component.ts
@@ -170,30 +170,43 @@ export class StudioComponent implements OnDestroy, OnInit {
       },
     };
     this.shepherdService.keyboardNavigation = false;
-    text_file_step["when"] = {
-      show: () => {
+
+    const cachedTextInputMode = this.studioService.inputMethod.text;
+    const setTextInputMode = (mode: string) => {
+      return () => {
         if (this.upload) {
-          this.studioService.inputMethod.text = "upload";
+          this.studioService.inputMethod.text = mode;
         }
-      },
-      hide: () => {
-        if (this.upload) {
-          this.studioService.inputMethod.text = "edit";
-        }
-      },
+      };
     };
-    audio_file_step["when"] = {
-      show: () => {
-        if (this.upload) {
-          this.studioService.inputMethod.audio = "upload";
-        }
-      },
-      hide: () => {
-        if (this.upload) {
-          this.studioService.inputMethod.audio = "mic";
-        }
-      },
+
+    text_write_step.when = {
+      show: setTextInputMode("edit"),
+      hide: setTextInputMode(cachedTextInputMode),
     };
+    text_file_step.when = {
+      show: setTextInputMode("upload"),
+      hide: setTextInputMode(cachedTextInputMode),
+    };
+
+    const cachedAudioInputMode = this.studioService.inputMethod.audio;
+    const setAudioInputMode = (mode: string) => {
+      return () => {
+        if (this.upload) {
+          this.studioService.inputMethod.audio = mode;
+        }
+      };
+    };
+
+    audio_record_step.when = {
+      show: setAudioInputMode("mic"),
+      hide: setAudioInputMode(cachedAudioInputMode),
+    };
+    audio_file_step.when = {
+      show: setAudioInputMode("upload"),
+      hide: setAudioInputMode(cachedAudioInputMode),
+    };
+
     if (this.formIsDirty()) {
       step_one_final_step["text"] =
         $localize`Once you've done this, you can click the "next step" button here to let Studio build your ReadAlong! (This may take a few seconds.)` +


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Addresses two minor issues with Studio Web tours. 

In the studio component, the tour text that does not align with the highlighted section of the page.

In the editor component, the tour fails to mention that the current data will be overwritten. 


### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

Fixes #428 
Fixes #427 


### Feedback sought? <!-- What should reviewers focus on in particular? -->

Works as expected.

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

Low.

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

None.

### How to test? <!-- Explain how reviewers should test this PR. -->

#### Studio

- Click on both "File" options
- Start the tour.
- When the tour gets to the `<textarea />` section, it should be the element highlighted.
- When the tour gets to the text file upload  section, it should be the element highlighted.
- When the tour gets to the record audio section, it should be the element highlighted.
- When the tour gets to the audio file upload  section, it should be the element highlighted.

Additionally, the tour now reverts these "Write | File" and "Record | File" choices back to what they were prior to the tour. 

#### Editor

- Start a new Tour. 
- At the second step, the tour should now warn the user that their data will be overwritten.


### Confidence? <!-- How confident are you that these changes are ready to merge? -->

High.

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->



<!-- Add any other relevant information here -->
