### PR TITLE
fix: added explicit utf-8 encoding for PowerShell users

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,8 @@ This will update `packages/studio-web/src/i18n/messages.json` with the English s
 Add or correct their translations in `messages.es.json` and `messages.fr.json`.
 (See `packages/studio-web/extract-i18n-lang.ts` for partial automation of that task.)
 
+    npx tsx packages/studio-web/extract-i18n-lang.ts --help
+
 Finally, run this check to confirm all the required strings are present in each language:
 
     npx nx check-l10n studio-web

--- a/packages/studio-web/extract-i18n-lang.ts
+++ b/packages/studio-web/extract-i18n-lang.ts
@@ -1,35 +1,106 @@
-// Update the language files with the new keys from the English file
-// Usage:
-//   npx tsx extract-i18n-lang.ts src/i18n/messages.json src/i18n/messages.fr.json > src/i18n/messages.fr-updated.json
-//   npx tsx extract-i18n-lang.ts src/i18n/messages.json src/i18n/messages.es.json > src/i18n/messages.es-updated.json
-// and then manually inspect the results, translate the new keys and copy the
-// updated files back to the original files.
-
 import fs from "fs";
 import process from "process";
+import { parseArgs } from "node:util";
 
-// Get the messages file from the command line
-const englishMessagesFile = process.argv[2];
-const languageMessagesFile = process.argv[3];
+function showHelp() {
+  console.log(`Update the language files with the new keys from the English file.
 
-// Check if filename is provided
-if (!englishMessagesFile || !languageMessagesFile) {
-  console.error(
-    "Please provide the English message file and translated message file as first and second CLI argument",
-  );
-  process.exit(1);
+Then manually inspect the results, translate the new keys and copy the
+updated files back to the original files.
+
+Usage:
+    npx tsx extract-i18n-lang.ts [options] englishFile otherLanguageFile
+
+Options:
+    --output filePath   writes the utf-8 encoded data to the specified output file
+    -i, --inplace       overwrites the translated language file
+    -h, --help              displays this message
+
+Examples:
+    npx tsx extract-i18n-lang.ts src/i18n/messages.json src/i18n/messages.fr.json > src/i18n/messages.fr-updated.json
+    npx tsx extract-i18n-lang.ts src/i18n/messages.json src/i18n/messages.es.json > src/i18n/messages.es-updated.json
+
+    npx tsx extract-i18n-lang.ts --output src/i18n/messages.es-updated.json src/i18n/messages.json src/i18n/messages.es.json
+    npx tsx extract-i18n-lang.ts --inplace src/i18n/messages.json src/i18n/messages.es.json
+
+Note:
+    In a Windows PowerShell environment, please use either the --output or the --inplace flags.
+`);
 }
 
-// Read the English file synchronously
-const englishDataRaw = fs.readFileSync(englishMessagesFile, "utf8");
-const englishData = JSON.parse(englishDataRaw);
-//console.log(englishDataParsed);
+function parseCommandLine() {
+  const { values: flags, positionals: args } = parseArgs({
+    args: process.argv.slice(2),
+    options: {
+      output: {
+        type: "string",
+        default: "-",
+      },
+      inplace: { type: "boolean", short: "i" },
+      help: { type: "boolean", short: "h" },
+    },
+    allowPositionals: true,
+  });
 
-// Read the language file synchronously
-const languageDataRaw = fs.readFileSync(languageMessagesFile, "utf8");
-let languageData = JSON.parse(languageDataRaw);
-//assert(englishData, 'English data is null');
-//assert(languageData, 'Language data is null');
+  // show help message
+  if (flags.help) {
+    showHelp();
+    process.exit(0);
+  }
+
+  // Check if filenames are provided
+  if (args.length < 2) {
+    console.error(
+      "Please provide the English message file and translated message file as first and second CLI argument",
+    );
+    process.exit(1);
+  }
+
+  // In-place implementation, replace the output file with the
+  // source of the translated data, but only if the user has not
+  // specified an output file path.
+  if (flags.output === "-" && flags.inplace) {
+    flags.output = args[1];
+  }
+
+  // If a Windows user is using stdout, provide a warning message. This is really targeted
+  // at PowerShell users but we cannot reliably determine which shell is being used.
+  if (process.platform === "win32" && flags.output === "-") {
+    console.error(
+      "Windows warning: please provide either the --output or --inplace flags to generate a valid utf-8 file",
+    );
+  }
+
+  return { flags, args };
+}
+
+interface TranslationFile {
+  locale: string;
+  translations: {
+    [key: string]: string;
+  };
+}
+
+function readJSON(filePath: string): TranslationFile {
+  try {
+    const rawData = fs.readFileSync(filePath, "utf8");
+    return JSON.parse(rawData);
+  } catch (err: any) {
+    console.error(
+      `An error occurred while reading "${filePath}":\n   ${"message" in err ? err.message : err}`,
+    );
+    process.exit(1);
+  }
+}
+
+// Get the arguments from the command line
+const { flags, args } = parseCommandLine();
+
+const englishMessagesFile = args[0];
+const languageMessagesFile = args[1];
+
+const englishData = readJSON(englishMessagesFile);
+const languageData = readJSON(languageMessagesFile);
 
 for (const key in englishData.translations) {
   if (!languageData.translations[key]) {
@@ -46,12 +117,28 @@ for (const key in languageData.translations) {
     delete languageData.translations[key];
   }
 }
-//console.log(languageData)
 
-let sortedTranslations: any = {};
+const sortedTranslations: any = {};
 for (const key in englishData.translations) {
   sortedTranslations[key] = languageData.translations[key];
 }
-//console.log(sortedTranslations);
 languageData.translations = sortedTranslations;
-console.log(JSON.stringify(languageData, null, 2));
+
+// Save the new translated file to the user provided output path.
+try {
+  const writer =
+    flags.output !== "-" ? fs.openSync(flags.output, "w") : process.stdout.fd;
+
+  fs.writeSync(
+    writer,
+    Buffer.from(JSON.stringify(languageData, null, 2), "utf-8"),
+  );
+
+  fs.closeSync(writer);
+} catch (err: any) {
+  console.error(
+    `An error occurred while saving the new translation file:\n` +
+      `   ${"message" in err ? err.message : err}`,
+  );
+  process.exit(1);
+}


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Fixes the `extract-i18n-lang.ts` utility to script, so that it can be used in PowerShell. Using `>` redirect in PowerShell seems generates non-UTF8 files. This PR mitigates this by:

- new `--output` and `--inplace` flags that explicitly writes a utf-8 file without relying on redirections.
- new `--help` flag that describes the tool, with a note for PowerShell users. 
- README.md has been updated to document a first execution of the script with `--help`
- the script attempts to determine if the user's environment is a PowerShell. Logs a warning message if redirection might be in use.
- redirect is still available by omitting `--output` and `--inline`, or specifying `-` as the output file name: `--output -`

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

Fixes #415 

### Feedback sought? <!-- What should reviewers focus on in particular? -->

That it works correctly. Special request for reviewers with access to PowerShell, see How To Test.

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

Low, non blocking.

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

No.

### How to test? <!-- Explain how reviewers should test this PR. -->

- Test the new `--help` flag and its content:

```bash
npx tsx packages/studio-web/extract-i18n-lang.ts  --help
```


For the rest of the examples, you can create a new translation file by running the following command:
```bash
echo '{"translations": {}}' > test-translation.json
```

- Output translated content to stdout:
```bash
npx tsx packages/studio-web/extract-i18n-lang.ts  packages/studio-web/src/i18n/messages.json test-translation.json
```

- Output translated content to original file with `--inplace`, and report the number of lines in new file (181).
```bash
npx tsx packages/studio-web/extract-i18n-lang.ts --inplace packages/studio-web/src/i18n/messages.json test-translation.json
wc -l test-translation.json
```

- Create a new file with `--output` and compare with source translation file.
```bash
npx tsx packages/studio-web/extract-i18n-lang.ts --output test-translation-updated.json packages/studio-web/src/i18n/messages.json test-translation.json
diff test-translation-updated.json test-translation.json
```

#### Special requests for reviewers with PowerShell

- It's possible that this new implementation now works with PowerShell redirects. The new file should be utf-8 encoded:
```bash
npx tsx packages/studio-web/extract-i18n-lang.ts  packages/studio-web/src/i18n/messages.json test-translation.json > test-translation-updated.json
```
- the previous command should have logged a PowerShell warning. 

#### Cleanup

```bash
rm test-translation.json
rm test-translation-updated.json
```

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

High, except for the PowerShell functionality.

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->



<!-- Add any other relevant information here -->
