### PR TITLE
ci: make the npm release last since it is not reversible

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,16 +41,6 @@ jobs:
         run: |
           sed -i 's/(\.\.\/web-component)/(web-component)/g' dist/packages/ngx-web-component/README.md
           sed -i 's/(test-data\//(https:\/\/github.com\/ReadAlongs\/Studio-Web\/blob\/${{ github.ref_name }}\/packages\/web-component\/test-data\//g' dist/packages/web-component/README.md
-      - name: Publish web-component to npmjs
-        run: |
-          cd dist/packages/web-component && npm publish --access=public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - name: Publish ngx-web-component to npmjs
-        run: |
-          cd dist/packages/ngx-web-component && npm publish --access=public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Update CHANGELOG
         id: changelog
         uses: requarks/changelog-action@v1
@@ -65,6 +55,16 @@ jobs:
           tag: ${{ github.ref_name }}
           name: Release ${{ github.ref_name }}
           body: ${{ steps.changelog.outputs.changes }}
+      - name: Publish web-component to npmjs
+        run: |
+          cd dist/packages/web-component && npm publish --access=public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish ngx-web-component to npmjs
+        run: |
+          cd dist/packages/ngx-web-component && npm publish --access=public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   deploy:
     needs: publish


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Since GitHub releases can be delete but npmjs published packages cannot, the `npm publish` steps should be the very last ones we run.

This way, when something fails, we can just delete the release on GitHub and push the tag again.

### Feedback sought? <!-- What should reviewers focus on in particular? -->

Sanity checking

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

High - before we publish 1.6.0

### How to test? <!-- Explain how reviewers should test this PR. -->

Can't test this without creating a fake repo and all, but I'm just interchanging two blocks in the workflow, so I think it's safe.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

<!-- Add any other relevant information here -->
