### PR TITLE
fix(build): access stylus from github instead of npmjs due to admin error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28616,8 +28616,7 @@
     },
     "node_modules/stylus": {
       "version": "0.64.0",
-      "resolved": "https://registry.npmjs.org/stylus/-/stylus-0.64.0.tgz",
-      "integrity": "sha512-ZIdT8eUv8tegmqy1tTIdJv9We2DumkNZFdCF5mz/Kpq3OcTaxSuCAYZge6HKK2CmNC02G1eJig2RV7XTw5hQrA==",
+      "resolved": "git+ssh://git@github.com/stylus/stylus.git#1086c6c1fbd7a7fd0ce9ad94f6cf4a62fc79a6e9",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -74,6 +74,9 @@
     "unidecode": "^1.1.0",
     "wavesurfer.js": "^6.6.4"
   },
+  "overrides": {
+    "stylus": "github:stylus/stylus#0.64.0"
+  },
   "scripts": {
     "prepare": "husky"
   },


### PR DESCRIPTION



<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Work around the fact that npmjs banned stylus, purportedly by accident.

See 
https://www.bleepingcomputer.com/news/security/npm-accidentally-removes-stylus-package-breaks-builds-and-pipelines/ https://github.com/stylus/stylus/issues/2938

I'm submitting this PR for info, but the better solution is to wait for them to fix things.

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

Del is demo'ing the CSS editor Monday to a community, so if npmjs doesn't fix things soon, we might need to merge this PR.

