### PR TITLE
fix: removed custom css from studio demo component

### DIFF
--- a/packages/studio-web/playwright.config.ts
+++ b/packages/studio-web/playwright.config.ts
@@ -41,17 +41,32 @@ export default defineConfig({
     ? [
         {
           name: "chromium",
-          use: { ...devices["Desktop Chrome"] },
+          use: {
+            ...devices["Desktop Chrome"],
+            contextOptions: {
+              permissions: ["clipboard-read", "clipboard-write"],
+            },
+          },
         },
         {
           name: "Mobile Chrome",
-          use: { ...devices["Pixel 5"] },
+          use: {
+            ...devices["Pixel 5"],
+            contextOptions: {
+              permissions: ["clipboard-read", "clipboard-write"],
+            },
+          },
         },
       ]
     : [
         {
           name: "chromium",
-          use: { ...devices["Desktop Chrome"] },
+          use: {
+            ...devices["Desktop Chrome"],
+            contextOptions: {
+              permissions: ["clipboard-read", "clipboard-write"],
+            },
+          },
         },
 
         {
@@ -67,7 +82,12 @@ export default defineConfig({
         /* Test against mobile viewports. */
         {
           name: "Mobile Chrome",
-          use: { ...devices["Pixel 5"] },
+          use: {
+            ...devices["Pixel 5"],
+            contextOptions: {
+              permissions: ["clipboard-read", "clipboard-write"],
+            },
+          },
         },
         /*
         {

--- a/packages/studio-web/src/app/demo/demo.component.ts
+++ b/packages/studio-web/src/app/demo/demo.component.ts
@@ -24,7 +24,6 @@ export class DemoComponent implements OnDestroy, OnInit {
     public studioService: StudioService,
     private downloadService: DownloadService,
     private toastr: ToastrService,
-    private wcStylingService: WcStylingService,
   ) {
     // If we do more languages, this should be a lookup table
     if ($localize.locale == "fr") {
@@ -32,12 +31,6 @@ export class DemoComponent implements OnDestroy, OnInit {
     } else if ($localize.locale == "es") {
       this.language = "spa";
     }
-    this.wcStylingService.$wcStyleInput.subscribe((css) =>
-      this.updateWCStyle(css),
-    );
-    this.wcStylingService.$wcStyleFonts.subscribe((font) =>
-      this.addWCCustomFont(font),
-    );
   }
 
   ngOnInit(): void {}
@@ -54,8 +47,6 @@ export class DemoComponent implements OnDestroy, OnInit {
         this.studioService.b64Inputs$.value[1],
         this.studioService.slots,
         this.readalong,
-        "Studio",
-        this.wcStylingService,
       );
     } else {
       this.toastr.error($localize`Download failed.`, $localize`Sorry!`, {
@@ -80,13 +71,5 @@ export class DemoComponent implements OnDestroy, OnInit {
         this.readalong,
       );
     }
-  }
-  async updateWCStyle($event: string) {
-    this.readalong?.setCss(
-      `data:text/css;base64,${this.b64Service.utf8_to_b64($event ?? "")}`,
-    );
-  }
-  async addWCCustomFont($font: string) {
-    this.readalong?.addCustomFont($font);
   }
 }

--- a/packages/studio-web/src/app/editor/editor.component.ts
+++ b/packages/studio-web/src/app/editor/editor.component.ts
@@ -209,8 +209,8 @@ export class EditorComponent implements OnDestroy, OnInit, AfterViewInit {
         this.editorService.rasControl$.value,
         this.editorService.slots,
         this.readalong,
-        "Editor", //from
         this.wcStylingService,
+        "Editor",
       );
     } else {
       this.toastr.error($localize`Download failed.`, $localize`Sorry!`, {

--- a/packages/studio-web/src/app/shared/download/download.service.ts
+++ b/packages/studio-web/src/app/shared/download/download.service.ts
@@ -181,14 +181,18 @@ Please host all assets on your server, include the font and package imports defi
     readalong: Components.ReadAlong,
     slots: ReadAlongSlots,
     b64Audio: string,
-    wcStylingService: WcStylingService,
+    wcStylingService: WcStylingService | null,
   ) {
     await this.updateImages(rasDoc, true, "image", readalong);
     await this.updateTranslations(rasDoc, readalong);
     let rasB64 = this.b64Service.xmlToB64(rasDoc);
     let b64Css = "";
-    const cssText = wcStylingService.$wcStyleInput.getValue();
-    const customFont = wcStylingService.$wcStyleFonts.getValue();
+    const cssText = wcStylingService
+      ? wcStylingService.$wcStyleInput.getValue()
+      : "";
+    const customFont = wcStylingService
+      ? wcStylingService.$wcStyleFonts.getValue()
+      : "";
     if (cssText) {
       b64Css = `\n      css-url="data:text/css;base64,${this.b64Service.utf8_to_b64(cssText)}"`;
     }
@@ -272,11 +276,16 @@ Please host all assets on your server, include the font and package imports defi
     rasXML: Document,
     slots: ReadAlongSlots,
     readalong: Components.ReadAlong,
+    wcStylingService: WcStylingService | null = null,
     from: "Studio" | "Editor" = "Studio",
-    wcStylingService: WcStylingService,
   ) {
-    const cssText = wcStylingService.$wcStyleInput.getValue();
-    const customFont = wcStylingService.$wcStyleFonts.getValue();
+    const cssText = wcStylingService
+      ? wcStylingService.$wcStyleInput.getValue()
+      : "";
+    const customFont = wcStylingService
+      ? wcStylingService.$wcStyleFonts.getValue()
+      : "";
+
     if (selectedOutputFormat == SupportedOutputs.html) {
       var element = document.createElement("a");
       const blob = await this.createSingleFileBlob(


### PR DESCRIPTION
### PR Goal? <!-- Explain the main objective of this PR. -->

Corrects a potentially confusing bug where custom CSS impacts Studio exported "Offline HTML" and "Web Bundle" formats.

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

Fixes #448 


### Feedback sought? <!-- What should reviewers focus on in particular? -->

Everything still works.


### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

Medium.


### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

No, but some tweaks to existing tests. Firefox clipboard permissions are not configurable.

### How to test? <!-- Explain how reviewers should test this PR. -->

Follow steps in original issue #448. The download file should not have a red background anymore (or any custom CSS).


### Confidence? <!-- How confident are you that these changes are ready to merge? -->

High.


### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->



<!-- Add any other relevant information here -->
