### PR TITLE
refactor: updated B64Service and FileService to prefer FileReader API

### DIFF
--- a/packages/studio-web/src/app/demo/demo.component.html
+++ b/packages/studio-web/src/app/demo/demo.component.html
@@ -27,9 +27,7 @@
           #readalong
           *ngIf="studioService.render$ | async"
           mode="EDIT"
-          href="data:application/readalong+xml;base64,{{
-            b64Service.xmlToB64(b64Inputs[1])
-          }}"
+          href="{{ rasAsDataURL() }}"
           audio="{{ b64Inputs[0] }}"
           class="hydrated"
         >

--- a/packages/studio-web/src/app/demo/demo.component.ts
+++ b/packages/studio-web/src/app/demo/demo.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, ViewChild } from "@angular/core";
+import { Component, OnDestroy, OnInit, signal, ViewChild } from "@angular/core";
 import { Components } from "@readalongs/web-component/loader";
 
 import { B64Service } from "../b64.service";
@@ -16,7 +16,7 @@ import { ToastrService } from "ngx-toastr";
 export class DemoComponent implements OnDestroy, OnInit {
   @ViewChild("readalong") readalong!: Components.ReadAlong;
   language: "eng" | "fra" | "spa" = "eng";
-
+  protected rasAsDataURL = signal<string>("");
   constructor(
     public b64Service: B64Service,
     public studioService: StudioService,
@@ -29,6 +29,12 @@ export class DemoComponent implements OnDestroy, OnInit {
     } else if ($localize.locale == "es") {
       this.language = "spa";
     }
+
+    this.studioService.b64Inputs$.subscribe(async (b64Input) => {
+      if (b64Input[1]) {
+        this.rasAsDataURL.set(await this.b64Service.rasToDataURL(b64Input[1]));
+      }
+    });
   }
 
   ngOnInit(): void {}

--- a/packages/studio-web/src/app/editor/editor.component.ts
+++ b/packages/studio-web/src/app/editor/editor.component.ts
@@ -269,7 +269,7 @@ export class EditorComponent implements OnDestroy, AfterViewInit {
       this.wavesurfer.loadBlob(this.editorService.audioControl$.value);
       this.wavesurfer.clearSegments();
       this.fileService
-        .readFileAsData$(this.editorService.audioControl$.value)
+        .readFileAsDataURL$(this.editorService.audioControl$.value)
         .pipe(take(1))
         .subscribe((audiob64) => {
           this.editorService.audioB64Control$.setValue(audiob64);
@@ -461,18 +461,12 @@ export class EditorComponent implements OnDestroy, AfterViewInit {
     const css = element.getAttribute("css-url");
 
     if (css !== null && css.length > 0) {
-      if (css.startsWith("data:text/css;base64,")) {
-        this.wcStylingService.$wcStyleInput.next(
-          this.b64Service.b64_to_utf8(css.substring(css.indexOf(",") + 1)),
-        );
-      } else {
-        const reply = await fetch(css);
-        // Did that work? Great!
-        if (reply.ok) {
-          reply.text().then((cssText) => {
-            this.wcStylingService.$wcStyleInput.next(cssText);
-          });
-        }
+      const reply = await fetch(css);
+      // Did that work? Great!
+      if (reply.ok) {
+        reply.text().then((cssText) => {
+          this.wcStylingService.$wcStyleInput.next(cssText);
+        });
       }
     } else {
       this.wcStylingService.$wcStyleInput.next("");
@@ -578,9 +572,11 @@ export class EditorComponent implements OnDestroy, AfterViewInit {
     this.shepherdService.start();
   }
   async updateWCStyle($event: string) {
-    this.readalong?.setCss(
-      `data:text/css;base64,${this.b64Service.utf8_to_b64($event ?? "")}`,
+    const css = await this.fileService.readFileAsDataURL(
+      $event ?? "",
+      "text/css",
     );
+    this.readalong?.setCss(css);
   }
   async addWCCustomFont($font: string) {
     this.readalong?.addCustomFont($font);

--- a/packages/studio-web/src/app/file.service.spec.ts
+++ b/packages/studio-web/src/app/file.service.spec.ts
@@ -25,4 +25,33 @@ describe("FileService", () => {
   it("should be created", () => {
     expect(service).toBeTruthy();
   });
+
+  it("should read a text file from a promise", async () => {
+    const got = await service.readFile("this is a test");
+    expect(got).toBe("this is a test");
+  });
+
+  it("should create a data URL from a promise", async () => {
+    const got = await service.readFileAsDataURL("this is a test");
+    expect(got.startsWith("data:text/plain;base64")).toBeTrue();
+
+    // reverse the readFileAsDataURL operation.
+    const reversed = await fetch(got).then((resp) => resp.text());
+    expect(reversed).toBe("this is a test");
+  });
+
+  it("should turn utf8 to b64 and back", async () => {
+    const testUTF8 = `󳬏ۓ脶򍫐䏷򻱚1󔊣򧰗J鷍ˑ⨘󝳗ʳꟴ󆋔=є򻥼Ӳ򦿴¦槩7}摠꾀𴮣۝م𬷊
+    ,^⒆!טФ񤨷Յe󫱷ъ"Ҁ*=ߋ󻅷񌍖_ᾀ\ꡝ񲁿g"՝MU񔡆ЀL
+    劆֒񦘰ˑ{坋𹔸lǼc&񓱬񊄸Ӽ:󌈅=̹ɽ渭觙􈯶൰ȣ¡圤𹷟򱄢揋ﺝ􊃻^
+    E̶򱩀򑪟eٌϐ򔜮霗燨综*􍪻񭚴oꕃ𷴨2ҽT񺆥uR혙񗊭:򉪼񙏺ۤƓ騡
+    񱺡􌡩PȌ񸛍񩍢􅓴冖㌃ۄ𦄜7Ž⇆*zѱ澁nަvۭË́듍JҢ䆹M󩗟繶`;
+
+    const got = await service
+      .readFileAsDataURL(testUTF8)
+      .then((dataURL) => fetch(dataURL))
+      .then((resp) => resp.text());
+
+    expect(got).toEqual(testUTF8);
+  });
 });

--- a/packages/studio-web/src/app/file.service.ts
+++ b/packages/studio-web/src/app/file.service.ts
@@ -1,4 +1,13 @@
-import { Observable, catchError, from, map, of, take } from "rxjs";
+import {
+  Observable,
+  Subscriber,
+  catchError,
+  from,
+  lastValueFrom,
+  map,
+  of,
+  take,
+} from "rxjs";
 import { HttpClient, HttpErrorResponse } from "@angular/common/http";
 import { Injectable } from "@angular/core";
 import { ToastrService } from "ngx-toastr";
@@ -17,14 +26,14 @@ export class FileService {
     file: File,
     sampleRate: number,
   ): Observable<AudioBuffer> {
-    var audioCtx = new AudioContext({ sampleRate });
-    var audioFile = file.arrayBuffer().then((buffer: any) => {
+    const audioCtx = new AudioContext({ sampleRate });
+    const audioFile = file.arrayBuffer().then((buffer: any) => {
       return audioCtx.decodeAudioData(buffer);
     });
     return from(audioFile);
   }
 
-  returnFileFromPath$ = (url: string, responseType: string = "blob") => {
+  returnFileFromPath$(url: string, responseType: string = "blob") {
     const httpOptions: Object = { responseType };
     return this.http.get<any>(url, httpOptions).pipe(
       catchError((err: HttpErrorResponse) => {
@@ -42,11 +51,18 @@ export class FileService {
       }),
       take(1),
     );
-  };
+  }
 
-  readFile$(blob: Blob | File): Observable<string> {
+  readFile$(
+    blob: Blob | File | string,
+    type: string = "text/plain",
+  ): Observable<string> {
+    if (typeof blob === "string") {
+      blob = new Blob([blob], { type: type });
+    }
+
     const reader = new FileReader();
-    return Observable.create((obs: any) => {
+    return new Observable((obs: any) => {
       reader.onerror = (err) => obs.error(err);
       reader.onabort = (err) => obs.error(err);
       reader.onload = () => obs.next(reader.result);
@@ -54,14 +70,38 @@ export class FileService {
       reader.readAsText(blob);
     });
   }
-  readFileAsData$(blob: Blob | File): Observable<any> {
+
+  // A promise based implementation of readFile$.
+  readFile(
+    blob: Blob | File | string,
+    type: string = "text/plain",
+  ): Promise<string> {
+    return lastValueFrom(this.readFile$(blob, type));
+  }
+
+  readFileAsDataURL$(
+    blob: Blob | File | string,
+    type: string = "text/plain",
+  ): Observable<string> {
+    if (typeof blob === "string") {
+      blob = new Blob([blob], { type: type });
+    }
+
     const reader = new FileReader();
-    return Observable.create((obs: any) => {
+    return new Observable((obs: any) => {
       reader.onerror = (err) => obs.error(err);
       reader.onabort = (err) => obs.error(err);
       reader.onload = () => obs.next(reader.result);
       reader.onloadend = () => obs.complete();
       reader.readAsDataURL(blob);
     });
+  }
+
+  // A promise based implementation of readFileAsDataURL$.
+  readFileAsDataURL(
+    blob: Blob | File | string,
+    type: string = "text/plain",
+  ): Promise<string> {
+    return lastValueFrom(this.readFileAsDataURL$(blob, type));
   }
 }

--- a/packages/studio-web/src/app/shared/download/download.service.ts
+++ b/packages/studio-web/src/app/shared/download/download.service.ts
@@ -18,6 +18,7 @@ import {
 import { Components } from "@readalongs/web-component/loader";
 import { WcStylingService } from "../wc-styling/wc-styling.service";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
+import { FileService } from "../../file.service";
 
 interface Image {
   path: string;
@@ -49,6 +50,8 @@ Please host all assets on your server, include the font and package imports defi
       type: "text/plain",
     },
   );
+
+  private fileService = inject(FileService);
 
   constructor(
     private uploadService: UploadService,
@@ -137,13 +140,12 @@ Please host all assets on your server, include the font and package imports defi
         // Remove any images that are there from before
         currentPage.querySelectorAll("graphic").forEach((e) => e.remove());
         let graphic = doc.createElementNS(null, "graphic");
-        // @ts-ignore
-        let blob = await fetch(img).then((r) => r.blob());
-        blob = await compress(blob, 0.75);
+        let blob = await fetch(img)
+          .then((r) => r.blob())
+          .then((blob) => compress(blob, 0.75));
         // Either embed the images directly
         if (b64Embed) {
-          let b64 = await this.b64Service.blobToB64(blob);
-          // @ts-ignore
+          const b64 = await this.b64Service.blobToDataURL(blob);
           graphic.setAttribute("url", b64);
           // or return a list of blobs and use the filename here
         } else {
@@ -185,21 +187,26 @@ Please host all assets on your server, include the font and package imports defi
   ) {
     await this.updateImages(rasDoc, true, "image", readalong);
     await this.updateTranslations(rasDoc, readalong);
-    let rasB64 = this.b64Service.xmlToB64(rasDoc);
-    let b64Css = "";
+    const rasB64 = await this.b64Service.rasToDataURL(rasDoc);
     const cssText = wcStylingService
       ? wcStylingService.$wcStyleInput.getValue()
       : "";
     const customFont = wcStylingService
       ? wcStylingService.$wcStyleFonts.getValue()
       : "";
-    if (cssText) {
-      b64Css = `\n      css-url="data:text/css;base64,${this.b64Service.utf8_to_b64(cssText)}"`;
+
+    const b64Css = cssText
+      ? `\n      css-url="${await this.fileService.readFileAsDataURL(cssText, "text/css")}"`
+      : "";
+
+    const jsAndFontsBundle = await this.b64Service.getBundle();
+    if (!jsAndFontsBundle) {
+      return undefined;
     }
-    if (this.b64Service.jsAndFontsBundle$.value !== null) {
-      let blob = new Blob(
-        [
-          `
+
+    return new Blob(
+      [
+        `
             <!DOCTYPE html>
 
             <!--
@@ -232,17 +239,17 @@ Please host all assets on your server, include the font and package imports defi
                 <meta name="generator" content="@readalongs/studio-web ${environment.packageJson.singleFileBundleVersion}">
                 <title>${slots.title}</title>
                 <style>
-            ${this.b64Service.jsAndFontsBundle$.value[1]}
+            ${jsAndFontsBundle[1]}
                 </style>
                 <style id="ra-wc-custom-font" type="text/css">${customFont}</style>
                 <script name="@readalongs/web-component" version="${environment.packageJson.singleFileBundleVersion}" timestamp="${environment.packageJson.singleFileBundleTimestamp}">
-            ${this.b64Service.jsAndFontsBundle$.value[0]}
+            ${jsAndFontsBundle[0]}
                 </script>
               </head>
               <body>
                 <read-along
                   version="${environment.packageJson.singleFileBundleVersion}"
-                  href="data:application/readalong+xml;base64,${rasB64}"
+                  href="${rasB64}"
                   audio="${b64Audio}"
                   image-assets-folder=""
                   ${b64Css}
@@ -253,14 +260,11 @@ Please host all assets on your server, include the font and package imports defi
               </body>
             </html>
           `
-            .replace(/\n            /g, "\n")
-            .trim(),
-        ],
-        { type: "text/html;charset=utf-8" },
-      );
-      return blob;
-    }
-    return undefined;
+          .replace(/\n            /g, "\n")
+          .trim(),
+      ],
+      { type: "text/html;charset=utf-8" },
+    );
   }
 
   createRASBasename(title: string) {

--- a/packages/studio-web/src/app/shared/wc-styling/wc-styling.component.ts
+++ b/packages/studio-web/src/app/shared/wc-styling/wc-styling.component.ts
@@ -84,12 +84,12 @@ export class WcStylingComponent implements OnInit {
     }
     // type == "ttf" ? "font/ttf" : "application/x-font-" + type + ";charset=utf-8"
     this.b64Service
-      .blobToB64(file)
+      .blobToDataURL(file)
       .then((data) => {
         this.fontDeclaration$.next(
           this.fontDeclaration$.getValue() +
             (this.fontDeclaration$.getValue().length > 1 ? ", " : "") +
-            `url(${(data as string).replace("application/octet-stream", type == "ttf" ? "application/x-ttf;charset=utf-8" : "application/x-font-" + type + ";charset=utf-8")}) format('${type?.replace("ttf", "truetype")}')`,
+            `url(${data.replace("application/octet-stream", type == "ttf" ? "application/x-ttf;charset=utf-8" : "application/x-font-" + type + ";charset=utf-8")}) format('${type?.replace("ttf", "truetype")}')`,
         );
         this.updateStyle();
         this.toastr.success(

--- a/packages/studio-web/src/app/studio/studio.component.ts
+++ b/packages/studio-web/src/app/studio/studio.component.ts
@@ -317,7 +317,7 @@ export class StudioComponent implements OnDestroy, OnInit {
     if (event[0] === "aligned") {
       const aligned_xml = createAlignedXML(event[2], event[3] as Segment);
       forkJoin([
-        this.fileService.readFileAsData$(event[1]), // audio
+        this.fileService.readFileAsDataURL$(event[1]), // audio
         of(aligned_xml),
       ])
         .pipe(takeUntilDestroyed(this.destroyRef$))


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Replaces custom base64 encoding implementation with `FileReader.readAsDataURL()` [MDN reference](https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readAsDataURL), which creates valid `data:mimetype;base64,` data URLs.  

The web component and font bundles are only fetched when required (by initiating a download). The results are cached for subsequent requests.
 
### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

n/a


### Feedback sought? <!-- What should reviewers focus on in particular? -->

Discussion on viability of the proposed solution. We could also officially deprecate and remove previous base64 functions: `utf8_to_b64()`,  `b64_to_utf8()` and `xmlToB64`. 

There's also an opportunity to migrate the remaining data URL methods from `B64Service` to `FileService`, isolating the `getBundle` methods to create a new `BundleService`.

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

Low.


### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

Yes.

### How to test? <!-- Explain how reviewers should test this PR. -->

- The demo component still works
- Offline HTML is still functional
- Web bundle is also functional.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

Medium.


### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->



<!-- Add any other relevant information here -->
