### PR TITLE
refactor: replaced unsubscribe mechanism with DestroyRef

### DIFF
--- a/packages/studio-web/src/app/demo/demo.component.ts
+++ b/packages/studio-web/src/app/demo/demo.component.ts
@@ -1,5 +1,3 @@
-import { Subject } from "rxjs";
-
 import { Component, OnDestroy, OnInit, ViewChild } from "@angular/core";
 import { Components } from "@readalongs/web-component/loader";
 
@@ -8,7 +6,7 @@ import { StudioService } from "../studio/studio.service";
 import { DownloadService } from "../shared/download/download.service";
 import { SupportedOutputs } from "../ras.service";
 import { ToastrService } from "ngx-toastr";
-import { WcStylingService } from "../shared/wc-styling/wc-styling.service";
+
 @Component({
   selector: "app-demo",
   templateUrl: "./demo.component.html",
@@ -18,7 +16,7 @@ import { WcStylingService } from "../shared/wc-styling/wc-styling.service";
 export class DemoComponent implements OnDestroy, OnInit {
   @ViewChild("readalong") readalong!: Components.ReadAlong;
   language: "eng" | "fra" | "spa" = "eng";
-  unsubscribe$ = new Subject<void>();
+
   constructor(
     public b64Service: B64Service,
     public studioService: StudioService,
@@ -56,8 +54,6 @@ export class DemoComponent implements OnDestroy, OnInit {
   }
 
   async ngOnDestroy() {
-    this.unsubscribe$.next();
-    this.unsubscribe$.complete();
     // Save translations, images and all other edits to the studio service when we exit
     if (this.studioService.b64Inputs$.value[1]) {
       await this.downloadService.updateTranslations(

--- a/packages/studio-web/src/app/shared/download/download.service.ts
+++ b/packages/studio-web/src/app/shared/download/download.service.ts
@@ -1,6 +1,5 @@
-import { Injectable } from "@angular/core";
+import { DestroyRef, inject, Injectable } from "@angular/core";
 import { HttpErrorResponse } from "@angular/common/http";
-import { Observable, Subject, takeUntil } from "rxjs";
 import { slugify } from "../../utils/utils";
 import { UploadService } from "../../upload.service";
 import { ToastrService } from "ngx-toastr";
@@ -18,6 +17,7 @@ import {
 } from "../../ras.service";
 import { Components } from "@readalongs/web-component/loader";
 import { WcStylingService } from "../wc-styling/wc-styling.service";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 
 interface Image {
   path: string;
@@ -28,7 +28,7 @@ interface Image {
   providedIn: "root",
 })
 export class DownloadService {
-  unsubscribe$ = new Subject<void>();
+  private destroyRef$ = inject(DestroyRef);
   xmlSerializer = new XMLSerializer();
   readmeFile = new Blob(
     [
@@ -483,7 +483,7 @@ Use the text editor to paste the snippet below in your WordPress page:
           },
           selectedOutputFormat,
         )
-        .pipe(takeUntil(this.unsubscribe$))
+        .pipe(takeUntilDestroyed(this.destroyRef$))
         .subscribe({
           next: (x: Blob) => saveAs(x, `${basename}.${selectedOutputFormat}`),
           error: (err: HttpErrorResponse) => this.reportRasError(err),

--- a/packages/studio-web/src/app/shared/wc-styling/wc-styling.component.ts
+++ b/packages/studio-web/src/app/shared/wc-styling/wc-styling.component.ts
@@ -1,7 +1,8 @@
 import {
   Component,
+  DestroyRef,
   ElementRef,
-  OnDestroy,
+  inject,
   OnInit,
   ViewChild,
 } from "@angular/core";
@@ -15,6 +16,7 @@ import {
 } from "@angular/material/dialog";
 import { B64Service } from "../../b64.service";
 import { MatButtonModule } from "@angular/material/button";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 
 @Component({
   selector: "app-wc-styling",
@@ -22,11 +24,11 @@ import { MatButtonModule } from "@angular/material/button";
   styleUrl: "./wc-styling.component.sass",
   standalone: false,
 })
-export class WcStylingComponent implements OnDestroy, OnInit {
+export class WcStylingComponent implements OnInit {
   styleText$ = new BehaviorSubject<string>("");
   fontDeclaration$ = new BehaviorSubject<string>("");
   inputType = "edit";
-  unsubscribe$ = new Subject<void>();
+  private destroyRef$ = inject(DestroyRef);
   collapsed$ = new BehaviorSubject<boolean>(true);
   @ViewChild("styleInputElement") styleInputElement: ElementRef;
   @ViewChild("fontInputElement") fontInputElement: ElementRef;
@@ -198,7 +200,7 @@ span.theme--dark.sentence__text {
   }
   async ngOnInit() {
     this.wcStylingService.$wcStyleInput
-      .pipe(takeUntil(this.unsubscribe$))
+      .pipe(takeUntilDestroyed(this.destroyRef$))
       .subscribe((css) => {
         if (this.styleText$.getValue().length < 1) {
           this.styleText$.next(css);
@@ -207,10 +209,6 @@ span.theme--dark.sentence__text {
       });
   }
 
-  ngOnDestroy(): void {
-    this.unsubscribe$.next();
-    this.unsubscribe$.complete();
-  }
   openHelpDialog(): void {
     this.dialog.open(WCStylingHelper, {
       width: "80vw",

--- a/packages/studio-web/src/app/upload/upload.component.ts
+++ b/packages/studio-web/src/app/upload/upload.component.ts
@@ -2,8 +2,6 @@
 import { ToastrService } from "ngx-toastr";
 import {
   Observable,
-  BehaviorSubject,
-  Subject,
   catchError,
   finalize,
   forkJoin,
@@ -11,7 +9,6 @@ import {
   of,
   switchMap,
   map,
-  takeUntil,
   throwError,
   firstValueFrom,
   take,
@@ -19,9 +16,10 @@ import {
 
 import {
   Component,
+  DestroyRef,
   ElementRef,
   EventEmitter,
-  OnDestroy,
+  inject,
   OnInit,
   Output,
   ViewChild,
@@ -45,6 +43,7 @@ import { BeamDefaults, SoundswallowerService } from "../soundswallower.service";
 import { TextFormatDialogComponent } from "../text-format-dialog/text-format-dialog.component";
 import { StudioService } from "../studio/studio.service";
 import { validateFileType } from "../utils/utils";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 
 @Component({
   selector: "app-upload",
@@ -52,7 +51,7 @@ import { validateFileType } from "../utils/utils";
   styleUrls: ["./upload.component.sass"],
   standalone: false,
 })
-export class UploadComponent implements OnDestroy, OnInit {
+export class UploadComponent implements OnInit {
   isLoaded = false;
   langs: Array<SupportedLanguage> = [];
   loading = false;
@@ -77,7 +76,7 @@ export class UploadComponent implements OnDestroy, OnInit {
   textUploadAccepts = ".txt,.xml,.readalong";
   audioUploadAccepts = ".mp3,.wav,.webm,.m4a";
 
-  unsubscribe$ = new Subject<void>();
+  private destroyRef$ = inject(DestroyRef);
   private route: ActivatedRoute;
   constructor(
     private router: Router,
@@ -91,20 +90,20 @@ export class UploadComponent implements OnDestroy, OnInit {
     public studioService: StudioService,
   ) {
     this.studioService.audioControl$.valueChanges
-      .pipe(takeUntil(this.unsubscribe$))
+      .pipe(takeUntilDestroyed(this.destroyRef$))
       .subscribe((audio) => this.uploadService.$currentAudio.next(audio));
     this.studioService.textControl$.valueChanges
-      .pipe(takeUntil(this.unsubscribe$))
+      .pipe(takeUntilDestroyed(this.destroyRef$))
       .subscribe((textBlob) => this.uploadService.$currentText.next(textBlob));
     this.studioService.$textInput
-      .pipe(takeUntil(this.unsubscribe$))
+      .pipe(takeUntilDestroyed(this.destroyRef$))
       .subscribe((textString) => {
         //provides user with warning if text size is above limit
         if (this.checkIsTextSizeBelowLimit())
           this.uploadService.$currentText.next(textString);
       });
     this.ssjsService.modelLoaded
-      .pipe(takeUntil(this.unsubscribe$))
+      .pipe(takeUntilDestroyed(this.destroyRef$))
       .subscribe((loaded) => {
         this.isLoaded = loaded;
       });
@@ -113,7 +112,7 @@ export class UploadComponent implements OnDestroy, OnInit {
   async ngOnInit() {
     this.rasService
       .getLangs$()
-      .pipe(takeUntil(this.unsubscribe$))
+      .pipe(takeUntilDestroyed(this.destroyRef$))
       .subscribe({
         next: (langs: Array<SupportedLanguage>) => {
           this.langs = langs
@@ -129,11 +128,6 @@ export class UploadComponent implements OnDestroy, OnInit {
           console.log(err);
         },
       });
-  }
-
-  ngOnDestroy(): void {
-    this.unsubscribe$.next();
-    this.unsubscribe$.complete();
   }
 
   reportRasError(err: HttpErrorResponse) {
@@ -499,7 +493,7 @@ Please check it to make sure all words are spelled out completely, e.g. write "4
               return possibleError;
             }
           }),
-          takeUntil(this.unsubscribe$),
+          takeUntilDestroyed(this.destroyRef$),
           finalize(() => (this.ssjsService.mode = BeamDefaults.strict)),
         )
         .subscribe({


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

The `.pipe(takeUntil(this.unsubscribe$))` pattern requires boilerplate code to close all observables. 

Angular introduced `DestroyRef` (in v16) and `takeUntilDestroyed` (in v19):

```typescript
...
private destroyRef$ = inject(DestroyRef); 
...
interval(1000)
      .pipe(takeUntilDestroyed(this.destroyRef$))
      .subscribe((value) => {
        console.log(value);
      });
```

- `DestroyRef` [reference](https://angular.dev/api/core/DestroyRef)
- `takeUntilDestroyed` [reference](https://angular.dev/api/core/rxjs-interop/takeUntilDestroyed)


### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

None, but two classes (demo and  editor components) did not properly implement `ngOnDestroy` boilerplate code.

### Feedback sought? <!-- What should reviewers focus on in particular? -->

Any comments or opinion on the proposed changed.

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

Low.

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

None

### How to test? <!-- Explain how reviewers should test this PR. -->



### Confidence? <!-- How confident are you that these changes are ready to merge? -->

High

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->



<!-- Add any other relevant information here -->
