### PR TITLE
fix: reduced the sensitivity of view modification checks

### DIFF
--- a/packages/studio-web/src/app/editor/editor.component.html
+++ b/packages/studio-web/src/app/editor/editor.component.html
@@ -42,7 +42,7 @@
           Offline-HTML file included in the Web Bundle download format.
         </p>
         <input
-          #textInputElement
+          #rasFileUpload
           (change)="onRasFileSelected($event)"
           class="form-control"
           name="text"


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

More sensitive handling of the browser-generated confirmation dialog when navigating away or closing a Readalong instance.

For Studio: 

- fixes a `beforeunload` bug that always returned a isDirty=yes response. 
- added checks to verify if the language controls have been changed
- the event handler was not removed when the studio component was destroyed, this led to the Editor component inheriting the studio component isDirty logic.

For Editor:

- added new isDirty logic targeting the Editor component.


### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

Closes #439 

### Feedback sought? <!-- What should reviewers focus on in particular? -->

Validation that the confirmation dialog only appears when it should (after meaningful user edits).

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

Medium.

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

No.

### How to test? <!-- Explain how reviewers should test this PR. -->

For Studio, any one of these should trigger the dialog box:

- typing text
- recording audio
- uploading a text or audio file
- changing the language from "Default" to "Specific"
- specifying a specific language

...and attempting to close or refresh the current tab.

For Editor:

- uploading a Offline HTML file.

...and attempting to close or refresh the current tab.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

High


### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->



<!-- Add any other relevant information here -->
