### PR TITLE
fix: text file delete button should not be visible when no file has been uploaded

### DIFF
--- a/packages/studio-web/src/app/upload/upload.component.html
+++ b/packages/studio-web/src/app/upload/upload.component.html
@@ -58,7 +58,7 @@
               <!-- </div> -->
             </div>
           </div>
-          @if (studioService.textControl$.value !== null) {
+          @if (textFileUpload.value) {
             <div class="row">
               <div class="col-12 offset-xl-8 col-xl-4">
                 <button


### PR DESCRIPTION


<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Fixes bug introduced by #451, where the text file upload delete button was visible even if the user has not uploaded a text file.

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

Fixes #456 

### Feedback sought? <!-- What should reviewers focus on in particular? -->

That it now works correctly.

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

Medium, bug fix and non-blocking.

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

### How to test? <!-- Explain how reviewers should test this PR. -->

- Type some text under the Text box in Write mode
- Click on File
- The "Delete" button is not be visible.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

High

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->



<!-- Add any other relevant information here -->
