### PR TITLE
fix: timing issue re-constructing RAS data URL

### DIFF
--- a/packages/studio-web/src/app/demo/demo.component.html
+++ b/packages/studio-web/src/app/demo/demo.component.html
@@ -20,7 +20,7 @@
     <div class="row"></div>
 
     <div class="row" *ngIf="studioService.b64Inputs$ | async as b64Inputs">
-      <div *ngIf="b64Inputs[0] && b64Inputs[1]">
+      <div *ngIf="b64Inputs[0] && b64Inputs[1] && rasAsDataURL()">
         <read-along
           id="readalong"
           [language]="language"


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Fixes a bug introduced in a previous PR. The demo component attempts to render the readalong component before the RAS data URL has been constructed. This appears when the users creates a new read along, then navigates to the Editor, then returns to the Studio component. 

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

 Fixes #458 


### Feedback sought? <!-- What should reviewers focus on in particular? -->

That it properly resolves the original bug.

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

High, tentatively a blocker for PR #450

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

No.

### How to test? <!-- Explain how reviewers should test this PR. -->

- fresh launch of the PR preview
- type a word in text
- record a second
- click Go to the next step
- click Editor
- click Studio
- **The error no longer occurs and the readalong is properly loaded.**

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

High.

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->



<!-- Add any other relevant information here -->
