### PR TITLE
fix: read-along does not refresh on text changes

### DIFF
--- a/packages/studio-web/src/app/demo/demo.component.ts
+++ b/packages/studio-web/src/app/demo/demo.component.ts
@@ -38,6 +38,9 @@ export class DemoComponent implements OnDestroy {
 
     this.studioService.b64Inputs$.subscribe(async (b64Input) => {
       if (b64Input[1]) {
+        // disable the read-along component until the
+        // `await` below is done and updates the dataUrl.
+        this.rasAsDataURL.set("");
         this.rasAsDataURL.set(await this.b64Service.rasToDataURL(b64Input[1]));
       }
     });


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Fixes bug where the `<read-along />` component in Step 2, displays the incorrect version of the text after a user edits the text.

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

Fixes #469 

### Feedback sought? <!-- What should reviewers focus on in particular? -->

That the bug has been fixed.

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

Medium, non-blocker.


### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->
No.


### How to test? <!-- Explain how reviewers should test this PR. -->

- fresh load
- enter any text, audio
- go to next step
- back to step 1
- change the text
- go to next step
- The text in the Read-Along should have been updated also.


### Confidence? <!-- How confident are you that these changes are ready to merge? -->

High, but I'm not convinced this is the best approach. 


### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->



<!-- Add any other relevant information here -->
