### PR TITLE
fix: first language is now capitalized

### DIFF
--- a/packages/studio-web/src/app/app.component.sass
+++ b/packages/studio-web/src/app/app.component.sass
@@ -16,6 +16,7 @@
 
 .language-selection
   text-transform: capitalize
+  display: inline-block
 
 .mat-accent > .mat-icon
   color: inherit


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Fixes the issue where the first language acronym in Studio-Web was not capitalized in chrome-based browsers.


### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

#471 

### Feedback sought? <!-- What should reviewers focus on in particular? -->

Works as expected.

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

Low, non blocker.

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

No.

### How to test? <!-- Explain how reviewers should test this PR. -->

Navigate to Studio-Web and confirm both language selectors ("fr" and "es") are properly capitalized: `Fr | Es`


### Confidence? <!-- How confident are you that these changes are ready to merge? -->

High

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->



<!-- Add any other relevant information here -->
