### PR TITLE
Dev.ej/better g2p toast

### DIFF
--- a/packages/studio-web/project.json
+++ b/packages/studio-web/project.json
@@ -82,7 +82,7 @@
       "defaultConfiguration": "production"
     },
     "update-browserslist": {
-      "command": "npx update-browserslist-db@latest"
+      "command": "npx -y update-browserslist-db@latest"
     },
     "serve": {
       "executor": "@angular-builders/custom-webpack:dev-server",

--- a/packages/studio-web/src/app/app.module.ts
+++ b/packages/studio-web/src/app/app.module.ts
@@ -40,7 +40,11 @@ defineCustomElements();
     BrowserModule,
     AppRoutingModule,
     BrowserAnimationsModule,
-    ToastrModule.forRoot(),
+    ToastrModule.forRoot({
+      preventDuplicates: true,
+      resetTimeoutOnDuplicate: true,
+      includeTitleDuplicates: true,
+    }),
     ReactiveFormsModule,
     MaterialModule,
     MatToolbarModule,

--- a/packages/studio-web/src/app/upload/upload.component.html
+++ b/packages/studio-web/src/app/upload/upload.component.html
@@ -116,6 +116,7 @@
                   class="border rounded b-0 p-0 bg-light"
                   rows="8"
                   matInput
+                  spellcheck="false"
                   i18n-placeholder="Example input text"
                   placeholder="Ex. Hello my name is...
 Sentence two.

--- a/packages/studio-web/src/app/upload/upload.component.ts
+++ b/packages/studio-web/src/app/upload/upload.component.ts
@@ -584,6 +584,7 @@ Please check it to make sure all words are spelled out completely, e.g. write "4
         next: (progress) => {
           if (progress.hypseg !== undefined) {
             this.loading = false;
+            this.toastr.clear(); // clean all outstanding toasts on alignment success
             this.stepChange.emit([
               "aligned",
               this.studioService.audioControl$.value,

--- a/packages/studio-web/src/app/upload/upload.component.ts
+++ b/packages/studio-web/src/app/upload/upload.component.ts
@@ -176,7 +176,10 @@ Please check it to make sure all words are spelled out completely, e.g. write "4
         );
       }
       this.toastr.error(err.error.detail, $localize`Text processing failed.`, {
-        timeOut: 30000,
+        timeOut: 180000,
+        closeButton: true,
+        tapToDismiss: false,
+        disableTimeOut: "extendedTimeOut",
       });
     } else {
       this.toastr.error(

--- a/packages/studio-web/tests/test-commands.ts
+++ b/packages/studio-web/tests/test-commands.ts
@@ -107,10 +107,17 @@ export const testMakeAReadAlong = async (page: Page) => {
     page.locator("#fileElem--t0b0d1").dispatchEvent("click");
     fileChooser = await fileChooserPromise;
     fileChooser.setFiles(testAssetsPath + "page2.png");
-    await page.locator("div.toast-message").last().click({ force: true });
-    await expect(async () => {
-      await expect(page.locator("div.toast-message")).not.toBeVisible();
-    }).toPass();
+    await page
+      .locator("div.toast-message")
+      .count()
+      .then(async (count) => {
+        if (count > 0) {
+          await page.locator("div.toast-message").last().click({ force: true });
+          await expect(async () => {
+            await expect(page.locator("div.toast-message")).not.toBeVisible();
+          }).toPass();
+        }
+      });
   });
 };
 


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

 - make the g2p error toast stay longer
 - enable copy-pasting from the g2p error toast by neither dismissing it on click nor on hover
 - clear all outstanding toasts on successful alignment, they're no longer relevant once we get to step 2
 - disable spell checking on the text area

### Feedback sought? <!-- What should reviewers focus on in particular? -->

Whether the updated app feels better

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

medium

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

no

### How to test? <!-- Explain how reviewers should test this PR. -->

enter `asdf 123 asdf : 1234` in the text box, and see:
 - `asdf` is no longer underlined as a spelling error
 - when you click on go to next step, you're able to interact with the g2p error toast without making go away
 - when you fix your text and align again, all the no-longer relevant toasts are gone

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

<!-- Add any other relevant information here -->
