### PR TITLE
fix: better messages when alignment fails

### DIFF
--- a/packages/studio-web/src/app/upload/upload.component.ts
+++ b/packages/studio-web/src/app/upload/upload.component.ts
@@ -189,8 +189,7 @@ Please check it to make sure all words are spelled out completely, e.g. write "4
 
   reportUnpronounceableError(err: Error) {
     this.toastr.error(
-      $localize`Your text may contain unpronounceable characters or numbers.
-Please check it to make sure all words are spelled out completely, e.g. write "42" as "forty two".`,
+      $localize`Unable to align even with loose alignment parameters. Please check your text and audio for quality and make sure they are a good match.`,
       $localize`Alignment failed.`,
       { timeOut: 30000 },
     );
@@ -201,13 +200,13 @@ Please check it to make sure all words are spelled out completely, e.g. write "4
       this.toastr.warning(
         $localize`Hmm, this is harder than usual, please wait while we try again.`,
         $localize`Alignment failed.`,
-        { timeOut: 5000 },
+        { timeOut: 10000 },
       );
     } else {
-      this.toastr.error(
+      this.toastr.warning(
         $localize`This is really difficult. We'll try one last time, but it might take a long time and produce poor results. Please make sure your text matches your audio and that there is as little background noise as possible.`,
         $localize`Alignment failed.`,
-        { timeOut: 30000 },
+        { timeOut: 20000 },
       );
     }
   }

--- a/packages/studio-web/src/i18n/messages.es.json
+++ b/packages/studio-web/src/i18n/messages.es.json
@@ -163,6 +163,7 @@
     "4812680719296626428": "Puede ser que su texto contenga caracteres impronunciables o números. Por favor verifique que todas las palabras están escritas en letras, por ejemplo escriba «cuarenta y dos» en vez de «42».",
     "858432719856825432": "Problemas de mapeo de pronunciación.",
     "9193890791359394027": "El procesamiento del texto falló.",
+    "9070810625387377245": "El alineamento falló incluso con parámetros relajados. Por favor verifique la calidad de su texto y audio y asegúrese de que coinciden bien.",
     "544933231530929418": "El alineamiento falló.",
     "3261201046681499271": "Hmm, esto es más difícil de lo habitual, espere mientras lo intentamos de nuevo.",
     "1549389605329660619": "Esto es realmente difícil. Lo intentaremos una última vez, pero puede llevar mucho tiempo y producir malos resultados. Asegúrese de que su texto coincida con su audio y que haya el menor ruido de fondo posible.",

--- a/packages/studio-web/src/i18n/messages.fr.json
+++ b/packages/studio-web/src/i18n/messages.fr.json
@@ -163,6 +163,7 @@
     "4812680719296626428": "Il pourrait y avoir des caractères non prononçables ou des chiffres dans votre texte. Prière d'écrire en toutes lettres, par exemple, « quarante deux » au lieu de « 42 ».",
     "858432719856825432": "Problèmes de conversion en prononciation.",
     "9193890791359394027": "Échec de traitement du texte.",
+    "9070810625387377245": "L'alignment n'a pas réussi même avec des paramètres relaxés. Prière de vérifier la qualité de votre texte et de votre audio et de vous assurer qu'ils correspondent bien.",
     "544933231530929418": "Échec d'alignement.",
     "3261201046681499271": "Hmm, c'est plus difficile que d'habitude, veuillez patienter pendant que nous réessayons.",
     "1549389605329660619": "C'est vraiment difficile. Nous allons essayer une dernière fois, mais ça peut être long et donner de mauvais résultats. Veuillez vous assurer que votre texte correspond à votre audio et qu'il y a le moins de bruit de fond possible.",

--- a/packages/studio-web/src/i18n/messages.json
+++ b/packages/studio-web/src/i18n/messages.json
@@ -163,6 +163,7 @@
     "4812680719296626428": "Your text may contain unpronounceable characters or numbers.\nPlease check it to make sure all words are spelled out completely, e.g. write \"42\" as \"forty two\".",
     "858432719856825432": "Pronunciation mapping issues.",
     "9193890791359394027": "Text processing failed.",
+    "9070810625387377245": "Unable to align even with loose alignment parameters. Please check your text and audio for quality and make sure they are a good match.",
     "544933231530929418": "Alignment failed.",
     "3261201046681499271": "Hmm, this is harder than usual, please wait while we try again.",
     "1549389605329660619": "This is really difficult. We'll try one last time, but it might take a long time and produce poor results. Please make sure your text matches your audio and that there is as little background noise as possible.",


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

When we get to the third alignment failure toast, the message was confusing and not helpful, so improve it.
When we get to the second alignment failure toast, it should be a warning only since we automatically try again.

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

The note quite intuitive messages we get on alignment failure.


Before | After
--- | ---
<img width="328" height="468" alt="image" src="https://github.com/user-attachments/assets/c4ce710a-5243-4b67-9a2e-ceb042778f7b" /> | <img width="318" height="410" alt="image" src="https://github.com/user-attachments/assets/f31fea94-9192-4096-99eb-2c80feeb412c" />

### Feedback sought? <!-- What should reviewers focus on in particular? -->

Do you agree this is more intuitive?

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

low

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

no

### How to test? <!-- Explain how reviewers should test this PR. -->

enter this as text:
```
This is a test, a very long test, and it cannot possibly be aligned to a second or two of noise, so alignment will eventually fail, with three distinct toasts popping up along the way.
```
record a second or two of noise

then click on go to the next step

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

medium high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

<!-- Add any other relevant information here -->
