### PR TITLE
fix: improve the g2p error toast so the user can interact with it

### DIFF
--- a/packages/studio-web/src/app/app.module.ts
+++ b/packages/studio-web/src/app/app.module.ts
@@ -40,7 +40,11 @@ defineCustomElements();
     BrowserModule,
     AppRoutingModule,
     BrowserAnimationsModule,
-    ToastrModule.forRoot(),
+    ToastrModule.forRoot({
+      preventDuplicates: true,
+      resetTimeoutOnDuplicate: true,
+      includeTitleDuplicates: true,
+    }),
     ReactiveFormsModule,
     MaterialModule,
     MatToolbarModule,

--- a/packages/studio-web/src/app/upload/upload.component.ts
+++ b/packages/studio-web/src/app/upload/upload.component.ts
@@ -176,7 +176,10 @@ Please check it to make sure all words are spelled out completely, e.g. write "4
         );
       }
       this.toastr.error(err.error.detail, $localize`Text processing failed.`, {
-        timeOut: 30000,
+        timeOut: 180000,
+        closeButton: true,
+        tapToDismiss: false,
+        disableTimeOut: "extendedTimeOut",
       });
     } else {
       this.toastr.error(


### PR DESCRIPTION
Replacing #483 by PRs doing one thing each, as I should have done in the first place...

This one improves the interaction with the g2p error toast:
 - let it live longer
 - don't dismiss on hover or click, so you can cut and paste contents out of it
 - give it a close button so you can still dismiss it

### How to test? <!-- Explain how reviewers should test this PR. -->

enter `asdf 123 asdf : 1234` in the text box, and see:
 - when you click on go to next step, you're able to interact with the g2p error toast without making go away

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high