### PR TITLE
perf: disable shards processing in CI

### DIFF
--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -74,76 +74,46 @@ jobs:
     name: Studio Web test-suites
     timeout-minutes: 60
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        shardIndex: [1, 2, 3]
-        shardTotal: [3]
     steps:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
+
       - uses: actions/setup-node@v6
         with:
           node-version: lts/*
-      - name: Install and run the back-end API, needed for end-to-end testing
+
+      - name: Install and run the back-end API
         run: |
           git clone https://github.com/ReadAlongs/Studio
           cd Studio
           pip install -e .[api]
           ./run-web-api.sh &
-          # wait for the API to be up
-          curl --retry 20 --retry-delay 1 --retry-all-errors http://localhost:8000/api/v1/langs
+
       - name: Install everything
         run: npm ci
+
       - name: Run studio-web in the background
         run: |
           npx nx build web-component
           npx nx run-many --targets=serve,serve-fr,serve-es --projects=web-component,studio-web --parallel 6 &
 
+      - name: Wait for the servers to be up
+        run: |
           # wait for the studio web to be up
           sleep 50
           curl --retry 20 --retry-delay 10 --retry-all-errors http://localhost:4200 > /dev/null
+          # Make sure the back-end API is up too
+          curl --retry 20 --retry-delay 1 --retry-all-errors http://localhost:8000/api/v1/langs
+
       - name: Run Playwright tests for studio-web
         run: |
           npx playwright install --with-deps chromium
-          npx nx e2e studio-web --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
-      - name: Upload blob report to GitHub Actions Artifacts
-        if: ${{ !cancelled() }}
+          npx nx e2e studio-web
+
+      - name: Upload HTML report
         uses: actions/upload-artifact@v6
         with:
-          name: blob-report-${{ matrix.shardIndex }}
-          path: packages/studio-web/blob-report
-          retention-days: 1
-
-  merge-reports:
-    # Merge reports after playwright-tests, even if some shards have failed
-    if: ${{ !cancelled() }}
-    needs: [studio-e2e-tests]
-    name: "Merge playwright reports from studio-web end-to-end tests"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - uses: actions/setup-node@v6
-        with:
-          node-version: lts/*
-      - name: Install everything
-        run: npm ci
-      - name: Download blob reports from GitHub Actions Artifacts
-        uses: actions/download-artifact@v7
-        with:
-          path: all-blob-reports
-          pattern: blob-report-*
-          merge-multiple: true
-
-      - name: Merge into a single HTML Report
-        run: npx playwright merge-reports --reporter=html,github ./all-blob-reports
-
-      - name: Upload single HTML report
-        uses: actions/upload-artifact@v6
-        with:
-          name: html-report--attempt-${{ github.run_attempt }}
-          path: playwright-report
+          name: playwright-report--attempt-${{ github.run_attempt }}
+          path: packages/studio-web/playwright-report
           retention-days: 5

--- a/packages/studio-web/playwright.config.ts
+++ b/packages/studio-web/playwright.config.ts
@@ -18,12 +18,12 @@ export default defineConfig({
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
-  /* Retry on CI only */
+  /* Retry only twice in CI */
   retries: process.env.CI ? 2 : 3,
-  /* Opt out of parallel tests on CI. */
+  /* Use 4 parallel workers in CI, the default otherwise (#CPUs I think). */
   workers: process.env.CI ? 4 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: process.env.CI ? [["blob", { open: "never" }]] : "html",
+  reporter: process.env.CI ? [["html", { open: "never" }]] : "html",
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */


### PR DESCRIPTION
There is too much overhead from npm install, it cancels all benefits from sharding

<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

We had end-to-end tests parallelized in three jobs, and merged after, but it turns out the overhead of the npm install required in each subjob makes the whole thing slower parallelized than in a single job.

Split example: 
https://github.com/ReadAlongs/Studio-Web/actions/runs/20348658434
shards took 3:49, 3:56, 3:33, merge took 1:11
time elapsed = 3:45 + 1:11 = 4:56
CI minutes used = sum = 12:29

Single job example:
https://github.com/ReadAlongs/Studio-Web/actions/runs/20374155875
non-parallel took 4:13 = time elapsed = CI minutes used

With my apologies for undoing this nice parallelization.

### Feedback sought? <!-- What should reviewers focus on in particular? -->

sanity check

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

normal

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

