### PR TITLE
fix: hide g2p warnings from the GUI, show them in console

### DIFF
--- a/packages/studio-web/src/app/upload/upload.component.ts
+++ b/packages/studio-web/src/app/upload/upload.component.ts
@@ -533,16 +533,8 @@ Please check it to make sure all words are spelled out completely, e.g. write "4
     })
       .pipe(
         switchMap(({ audio, ras }: { audio: IAudioBuffer; ras: ReadAlong }) => {
-          if (ras.log !== null) {
-            const fallbackRx = /^.*g2p.*$/gim;
-            const matches = ras.log.match(fallbackRx);
-            if (matches) {
-              this.toastr.warning(
-                matches.join("\n"),
-                $localize`Possible text processing issues.`,
-                { timeOut: 30000 },
-              );
-            }
+          if (ras.log) {
+            console.log("RAS Web API assemble/ log:\n" + ras.log);
           }
           return this.ssjsService.align$(audio, ras as ReadAlong);
         }),

--- a/packages/studio-web/src/i18n/messages.es.json
+++ b/packages/studio-web/src/i18n/messages.es.json
@@ -190,7 +190,6 @@
     "3861272198542491849": "No se ha cargado el modelo",
     "5640828320811588897": "Por favor seleccione o escriba el texto, seleccione o grabe el audio y seleccione el idioma.",
     "7065107025201081158": "Plantilla incompleta",
-    "7614709406289221963": "Posible problema con el procesamiento del texto.",
     "4232057340007056015": "El alineamento se realizó, pero con parámetros relajados. Por favor, revise el resultado para detectar posibles errores de alineación. Además, verifique la calidad de su texto y audio y asegúrese de que coincidan.",
     "4534823616345596361": "Alineación relajada exitosa",
     "6817170311264143962": "El fichero \"{$fileName}\" no es un fichero de audio compatible.",

--- a/packages/studio-web/src/i18n/messages.fr.json
+++ b/packages/studio-web/src/i18n/messages.fr.json
@@ -190,7 +190,6 @@
     "3861272198542491849": "Modèle non chargé",
     "5640828320811588897": "Prière de préparer votre texte et votre audio et de choisir une langue.",
     "7065107025201081158": "Formulaire incomplet",
-    "7614709406289221963": "Problèmes potentiels de traitement de texte.",
     "4232057340007056015": "L'alignment a réussi mais avec des paramètres relaxés. Prière de vérifier s'il y a des erreurs d'alignement dans le résultat. Vérifiez la qualité de votre texte et de votre audio et assurez-vous qu'ils correspondent.",
     "4534823616345596361": "Alignement relaxé réussi.",
     "6817170311264143962": "Le fichier \"{$fileName}\" n'est pas un fichier audio compatible.",

--- a/packages/studio-web/src/i18n/messages.json
+++ b/packages/studio-web/src/i18n/messages.json
@@ -190,7 +190,6 @@
     "3861272198542491849": "No model loaded",
     "5640828320811588897": "Please select or write text, select or record audio data, and select the language.",
     "7065107025201081158": "Form not complete",
-    "7614709406289221963": "Possible text processing issues.",
     "4232057340007056015": "Alignment succeeded, but with relaxed parameters. Please check the results for alignment errors, and please check your text and audio for quality and to make sure they are a good match.",
     "4534823616345596361": "Relaxed alignment succeeded.",
     "6817170311264143962": "The file \"{$fileName}\" is not a compatible audio file.",


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Marc noticed that sometimes our toast about g2p warnings can get really long, especially when aligning a long text, but it's not actually informative. 99% of users won't care that this or that word had to fall back to `und` or even understand what that means.

In brainstorming, Marc and I figured it would make more sense to `console.log()` the RAS web api log for the advanced user who wants to see them, but keep them out of the GUI because they're just visual noise to most users.

So that's what this PR does

### Feedback sought? <!-- What should reviewers focus on in particular? -->

I guess vetting that this idea makes sense.

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

normal

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

nope

### How to test? <!-- Explain how reviewers should test this PR. -->

 - Enter `test asdf test` in the text
 - any audio
 - select English as the language
 - and click "go to the next step"
 - See that the toast about g2p failing with `eng` for `asdf` is not diplayed, but if you open the console you'll see the full assemble log including the g2p warnings with header `RAS Web API assemble/ log:`.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

<!-- Add any other relevant information here -->
