### PR TITLE
fix: make npx nx bundle web component automatically build first

### DIFF
--- a/.github/workflows/bundle.yml
+++ b/.github/workflows/bundle.yml
@@ -18,7 +18,6 @@ jobs:
           package-manager-cache: false
       - run: npm install
       - run: npx update-browserslist-db@latest
-      - run: npx nx build web-component
       - run: npx nx bundle web-component
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725 # v8.0.0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,6 @@ jobs:
       - run: npx update-browserslist-db@latest
       - name: Build web-component
         run: |
-          npx nx build web-component
           # create the bundles required for studio-web
           # TODO: stop updating the bundle, keep the published one.
           npx nx bundle web-component

--- a/.github/workflows/dev-preview.yml
+++ b/.github/workflows/dev-preview.yml
@@ -23,7 +23,6 @@ jobs:
       - run: npx update-browserslist-db@latest
       - name: Build web-component
         run: |
-          npx nx build web-component
           # create the bundles required for studio-web
           npx nx bundle web-component
       - name: Test

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -34,7 +34,6 @@ jobs:
       - name: Build web-component
         if: github.event.action != 'closed'
         run: |
-          npx nx build web-component
           # create the bundles required for studio-web
           npx nx bundle web-component
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,6 @@ jobs:
       - run: npx update-browserslist-db@latest
       - name: Build and bundle
         run: |
-          npx nx build web-component
           npx nx bundle web-component
           npx nx build ngx-web-component
       - name: Fix the relative URLs in the READMEs to work on npmjs

--- a/packages/web-component/package.json
+++ b/packages/web-component/package.json
@@ -15,7 +15,7 @@
     "dist/"
   ],
   "scripts": {
-    "bundle": "bash bundle.sh",
+    "bundle": "npx nx build && bash bundle.sh",
     "linter:maticon": "node b64Fonts.js --validate",
     "cy:run": "npm run linter:maticon && cypress run",
     "test:full-pipeline": "npm run linter:maticon && npm run serve-test-data & nx run serve & npm run wait-for-test-server && npm run test:once",


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Forces a web component build when the bundle script is called, this avoids bundling a stale version of the readalong web component.

Also, since `npx nx bundle web-component` now performs a build operation, simplified the CI scripts to avoid unnecessary builds. 

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

Closes #445 

### Feedback sought? <!-- What should reviewers focus on in particular? -->


### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

Low

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

No

### How to test? <!-- Explain how reviewers should test this PR. -->

Not easy to test: one approach would be to 

* delete the `dist/packages/web-component/` directory. 
* `npx nx bundle web-component` succeeds (while on `main` it would not)

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

High

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

No

<!-- Add any other relevant information here -->
