### PR TITLE
revert: reimplement read alongs's getImages() API

### DIFF
--- a/packages/web-component/src/components/read-along-component/read-along.tsx
+++ b/packages/web-component/src/components/read-along-component/read-along.tsx
@@ -1472,8 +1472,10 @@ export class ReadAlongComponent {
       URL.revokeObjectURL(this.images[pageIndex]);
     }
 
-    delete this.images[pageIndex];
-    this.images = { ...this.images }; // Using spread operator as advised https://stenciljs.com/docs/reactive-data#updating-an-object
+    const newImage = {};
+    newImage[pageIndex] = null;
+
+    this.images = { ...this.images, ...newImage }; // Using spread operator as advised https://stenciljs.com/docs/reactive-data#updating-an-object
   }
 
   /**********


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Reverts an inadvertent API  change to the web component's `getImages()` functionality. The correct API should return an object with `null` values for images that had been deleted from the read along:

```javascript
console.log(readalong.getImages()); 
// {"1": "blob://...", "2": null}
```
Studio Web uses this `null` information as an indicator to remove a previously attached image from the download package.

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

Closes #502 

### Feedback sought? <!-- What should reviewers focus on in particular? -->

Still works as expected.

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

Low.

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

No.

### How to test? <!-- Explain how reviewers should test this PR. -->

* create a read along
* add an image
* create HTML export
* remove the image
* re-create HTML export 
* open the latest exported read along and image is  no longer included.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

High.

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

No.


<!-- Add any other relevant information here -->
