### PR TITLE
fix: provide a specific error message when recording permission is denied

### DIFF
--- a/packages/studio-web/src/app/upload/upload.component.ts
+++ b/packages/studio-web/src/app/upload/upload.component.ts
@@ -281,7 +281,15 @@ Please check it to make sure all words are spelled out completely, e.g. write "4
       await this.microphoneService.startRecording();
       this.recording = true;
     } catch (err: any) {
-      this.toastr.error(err.toString(), $localize`Could not start recording!`);
+      let message;
+      if (err.name === "NotAllowedError") {
+        message = $localize`Microphone access was denied. Please grant microphone access to use this feature.`;
+      } else {
+        message = err.toString();
+      }
+      this.toastr.error(message, $localize`Could not start recording!`, {
+        timeOut: 15000,
+      });
     } finally {
       this.starting_to_record = false;
     }

--- a/packages/studio-web/src/i18n/messages.es.json
+++ b/packages/studio-web/src/i18n/messages.es.json
@@ -169,6 +169,7 @@
     "1549389605329660619": "Esto es realmente difícil. Lo intentaremos una última vez, pero puede llevar mucho tiempo y producir malos resultados. Asegúrese de que su texto coincida con su audio y que haya el menor ruido de fondo posible.",
     "6071928720301938306": "El procesamiento del audio falló.",
     "3763839702998678686": "No hay audio para descargar.",
+    "3513286828638574591": "Permiso de micrófono denegado. Por favor, concede acceso al micrófono para grabar.",
     "4183225119057268962": "¡No se pudo empezar la grabación!",
     "2596823344081631983": "El audio se grabó con éxito. Por favor escuche su grabación para asegurarse de que está correcta y si lo está, guárdela para reusarla luego.",
     "1317075918959775059": "¡Hurra!",

--- a/packages/studio-web/src/i18n/messages.fr.json
+++ b/packages/studio-web/src/i18n/messages.fr.json
@@ -169,6 +169,7 @@
     "1549389605329660619": "C'est vraiment difficile. Nous allons essayer une dernière fois, mais ça peut être long et donner de mauvais résultats. Veuillez vous assurer que votre texte correspond à votre audio et qu'il y a le moins de bruit de fond possible.",
     "6071928720301938306": "Échec de traitement de l'audio.",
     "3763839702998678686": "Pas d'audio à télécharger.",
+    "3513286828638574591": "Autorisation du micro refusée. Prière d'accorder l'accès au micro pour pouvoir enregistrer.",
     "4183225119057268962": "Impossible de démarrer l'enregistrement!",
     "2596823344081631983": "Audio enregistré avec succès. Prière d'écouter votre enregistrement pour le valider et de le sauvegarder s'il est bon.",
     "1317075918959775059": "Bravo!",

--- a/packages/studio-web/src/i18n/messages.json
+++ b/packages/studio-web/src/i18n/messages.json
@@ -169,6 +169,7 @@
     "1549389605329660619": "This is really difficult. We'll try one last time, but it might take a long time and produce poor results. Please make sure your text matches your audio and that there is as little background noise as possible.",
     "6071928720301938306": "Audio processing failed.",
     "3763839702998678686": "No audio to download.",
+    "3513286828638574591": "Microphone access was denied. Please grant microphone access to use this feature.",
     "4183225119057268962": "Could not start recording!",
     "2596823344081631983": "Audio was successfully recorded. Please listen to your recording to make sure it's OK, and save it for reuse if so.",
     "1317075918959775059": "Yay!",


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

This is work I did a long time ago, but I forgot to PR it...

If microphone permission is denied, this PR shows:
<img width="332" height="138" alt="image" src="https://github.com/user-attachments/assets/463e69be-c48a-42f1-a785-8de4150598d3" />

Before this PR:
<img width="321" height="92" alt="image" src="https://github.com/user-attachments/assets/7fbb4687-4d65-48a7-a9f0-115a093231f6" />


### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

Fixes #149 
Well, really, it finishes fixing that issue by adding a friendlier user message when microphone permission is denied; the other half of the issue was done in #154, and all this is work that builds on top of #127.

### How to test? <!-- Explain how reviewers should test this PR. -->

Open the PR preview and the prod version in an incognito window, and refuse microphone access when prompted.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

<!-- Add any other relevant information here -->
