### PR TITLE
fix: make pause at end of page work with any translation

### DIFF
--- a/packages/web-component/src/components/read-along-component/read-along.tsx
+++ b/packages/web-component/src/components/read-along-component/read-along.tsx
@@ -1125,7 +1125,8 @@ export class ReadAlongComponent {
             const sentences = paragraphs[
               paragraphs.length - 1
             ].querySelectorAll(
-              "s:not(.translation), s:not(.sentence__translation)",
+              // chain the not statements so they are ANDed: exclude sentences matching any of these criteria
+              's:not(.translation):not(.sentence__translation):not([do-not-align="true"])',
             ); //get non-translation sentences in the last paragraph
             const word =
               sentences[sentences.length - 1].querySelector("w:last-of-type"); //get the last word of the last sentence


### PR DESCRIPTION


<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

We were excluding sentences that had both class .translation and class .sentence__translation from the list of sentences to figure how which is the last sentence in a page, but we should exclude any sentence with either of those classes, or with do-no-align=true.

Depending on how translations are added to a read-along, we don't always set both classes, so let's filter out anything that might be a translation when we are playing in the web-component.

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

Fixes #578

### Feedback sought? <!-- What should reviewers focus on in particular? -->

sanity checking

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

high

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

no

### How to test? <!-- Explain how reviewers should test this PR. -->

 - load the 058 example from #578 in the editor
 - click gear menu and select "pause at the end of each page"
 - click play
 - see the pause work again

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

We'll want to release this quickly since a user stumbled on it. Let's merge this, then #577, and then let's publish 1.6.4.

<!-- Add any other relevant information here -->
